### PR TITLE
debug: Deploy 단계에 로그 추가

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -38,6 +38,12 @@ jobs:
 
       - name: Deploy to Cloud Run (Dev)
         run: |
+          echo "=== Deploy Configuration ==="
+          echo "Project ID: ${{ secrets.GCP_PROJECT_ID }}"
+          echo "Region: asia-northeast3"
+          echo "Service: gotcha-be-dev"
+          echo "==========================="
+
           gcloud run deploy gotcha-be-dev \
             --source . \
             --platform managed \
@@ -47,3 +53,5 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --add-cloudsql-instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_DEV }} \
             --update-env-vars SPRING_PROFILES_ACTIVE=dev,SPRING_DATASOURCE_URL=${{ secrets.DB_URL_DEV }},SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME_DEV }},SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD_DEV }}
+
+          echo "=== Deploy completed ==="


### PR DESCRIPTION
cloud run 배포가 실패해서 확인해보기 위해 cicd-dev.yml에 로그 찍어봤습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 클라우드 배포 워크플로우에서 배포 구성 정보(프로젝트 ID, 리전, 서비스)와 완료 마커를 표시하는 로깅이 추가되었습니다. 배포 프로세스의 가시성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->