### PR TITLE
debug: gcloud run의 --quiet to --verbosity=info

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -49,7 +49,7 @@ jobs:
             --platform managed \
             --region asia-northeast3 \
             --allow-unauthenticated \
-            --quiet \
+            --verbosity=info \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --add-cloudsql-instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_DEV }} \
             --update-env-vars SPRING_PROFILES_ACTIVE=dev,SPRING_DATASOURCE_URL=${{ secrets.DB_URL_DEV }},SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME_DEV }},SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD_DEV }}


### PR DESCRIPTION
배포 왜 안되는지 확인위해 --quiet에서 --verbosity로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Dev 배포 단계의 배포 출력 설정을 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->