### PR TITLE
config: Cloud Run 리전을 도쿄(asia-northeast1)로 변경

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -32,8 +32,8 @@ jobs:
       # 4. Docker 빌드 및 Artifact Registry 푸시
       - name: Build and Push Docker Image
         run: |
-          gcloud auth configure-docker asia-northeast3-docker.pkg.dev
-          IMAGE_NAME="asia-northeast3-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/gotcha-repo/gotcha-be-dev:${{ github.sha }}"
+          gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+          IMAGE_NAME="asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/gotcha-repo/gotcha-be-dev:${{ github.sha }}"
           docker build -t $IMAGE_NAME .
           docker push $IMAGE_NAME
 
@@ -41,9 +41,9 @@ jobs:
       - name: Deploy to Cloud Run (Dev)
         run: |
           gcloud run deploy gotcha-be-dev \
-            --image asia-northeast3-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/gotcha-repo/gotcha-be-dev:${{ github.sha }} \
+            --image asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/gotcha-repo/gotcha-be-dev:${{ github.sha }} \
             --platform managed \
-            --region asia-northeast3 \
+            --region asia-northeast1 \
             --allow-unauthenticated \
             --port 8080 \
             --service-account github-actions@gotcha-483107.iam.gserviceaccount.com \

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -41,7 +41,7 @@ jobs:
           gcloud run deploy gotcha-be-prod \
             --source . \
             --platform managed \
-            --region asia-northeast3 \
+            --region asia-northeast1 \
             --allow-unauthenticated \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --add-cloudsql-instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_PROD }} \


### PR DESCRIPTION
서울 리전에서 직접 도메인 매핑 미지원으로 인한 변경
- Artifact Registry: asia-northeast3 → asia-northeast1
- Cloud Run 배포 리전: asia-northeast3 → asia-northeast1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 및 프로덕션 환경의 클라우드 배포 지역을 업데이트했습니다. 이미지 레지스트리와 배포 대상 지역이 일관되게 변경되었으며, 기타 배포 설정은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->