### PR TITLE
feat: Swagger 개발 도구 추가

### DIFF
--- a/src/main/java/com/gotcha/_global/config/OpenApiConfig.java
+++ b/src/main/java/com/gotcha/_global/config/OpenApiConfig.java
@@ -1,13 +1,15 @@
 package com.gotcha._global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -33,6 +35,8 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("GOTCHA API")
@@ -51,6 +55,15 @@ public class OpenApiConfig {
                         new Server()
                                 .url("https://api.gotcha.it.com")
                                 .description("Production Server")
-                ));
+                ))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("JWT Access Token만 입력 (Bearer 접두사 불필요)")))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName));
     }
 }

--- a/src/main/java/com/gotcha/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/gotcha/domain/auth/controller/DevAuthController.java
@@ -1,0 +1,42 @@
+package com.gotcha.domain.auth.controller;
+
+import com.gotcha._global.common.ApiResponse;
+import com.gotcha.domain.auth.jwt.JwtTokenProvider;
+import com.gotcha.domain.user.entity.User;
+import com.gotcha.domain.user.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dev", description = "개발용 API (local/dev 환경에서만 동작)")
+@RestController
+@RequestMapping("/api/dev")
+@RequiredArgsConstructor
+@Profile({"local", "dev"})
+public class DevAuthController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Operation(
+            summary = "테스트용 토큰 발급",
+            description = "userId로 테스트용 JWT 토큰을 발급합니다. local/dev 환경에서만 동작합니다."
+    )
+    @GetMapping("/token")
+    public ApiResponse<DevTokenResponse> getTestToken(@RequestParam Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        String accessToken = jwtTokenProvider.generateAccessToken(user);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        return ApiResponse.success(new DevTokenResponse(accessToken, refreshToken));
+    }
+
+    public record DevTokenResponse(String accessToken, String refreshToken) {}
+}


### PR DESCRIPTION
## Summary
- Swagger JWT Bearer 인증 스키마 추가 (Authorize 버튼)
- 개발용 토큰 발급 API 추가 (`GET /api/dev/token?userId={id}`)

## 변경 사항

### 1. OpenApiConfig
- JWT Bearer 인증 스키마 추가
- Swagger UI에서 Authorize 버튼으로 토큰 입력 가능

### 2. DevAuthController
- `@Profile({"local", "dev"})` - 운영 환경에서는 비활성화
- userId로 테스트용 토큰 발급

## 사용 방법

```bash
# 1. 토큰 발급
curl "http://localhost:8080/api/dev/token?userId=4"

# 2. API 테스트
curl "http://localhost:8080/api/users/me" \
  -H "Authorization: Bearer {accessToken}"
```

## Test plan
- [ ] `GET /api/dev/token?userId=4` 토큰 발급 확인
- [ ] Swagger Authorize 버튼 동작 확인
- [ ] prod 환경에서 /api/dev/** 비활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * JWT Bearer 인증 지원 추가로 API 보안 강화
  * 개발 환경용 토큰 생성 엔드포인트 추가

---

**단어 수: 24**

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->