### PR TITLE
fix: OAuth scope에 email 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,19 +21,19 @@ spring:
             redirect-uri: "{baseUrl}/api/auth/callback/kakao"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
-            scope: profile_image
+            scope: profile_image, account_email
             client-name: Kakao
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/api/auth/callback/google"
-            scope: profile
+            scope: profile, email
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/api/auth/callback/naver"
             authorization-grant-type: authorization_code
-            scope: profile_image
+            scope: profile_image, email
             client-name: Naver
         provider:
           kakao:


### PR DESCRIPTION
## Summary
- Kakao: `account_email` scope 추가
- Google: `email` scope 추가
- Naver: `email` scope 추가

## 배경
현재 소셜 로그인 시 이메일이 DB에 저장되지 않는 문제 발견 (모든 사용자 email이 NULL)

원인: OAuth scope 설정에 email 관련 scope가 누락되어 있었음

## 추가 작업 필요
- 카카오 개발자 콘솔: 동의항목에서 "카카오계정(이메일)" 수집 동의 설정
- 네이버 개발자 센터: API 설정에서 이메일 주소 항목 체크

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OAuth2 소셜 로그인 제공자(Kakao, Google, Naver)의 권한 범위를 업데이트했습니다. 이제 소셜 로그인 시 이메일 정보 접근 권한을 추가로 요청합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->