### PR TITLE
fix: Swagger 예제에 기본 프로필 이미지 URL 적용

### DIFF
--- a/src/main/java/com/gotcha/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
                                         "id": 1,
                                         "nickname": "빨간캡슐#21",
                                         "email": "user@example.com",
-                                        "profileImageUrl": null,
+                                        "profileImageUrl": "https://storage.googleapis.com/gotcha-dev-files/profile-default-join.png",
                                         "socialType": "KAKAO"
                                       }
                                     }
@@ -148,7 +148,7 @@ public class UserController {
                                         "id": 1,
                                         "nickname": "새닉네임#99",
                                         "email": "user@example.com",
-                                        "profileImageUrl": null,
+                                        "profileImageUrl": "https://storage.googleapis.com/gotcha-dev-files/profile-default-join.png",
                                         "socialType": "KAKAO"
                                       }
                                     }


### PR DESCRIPTION
## Summary
- 내 정보 조회 응답 예제: `profileImageUrl: null` → 기본 이미지 URL
- 닉네임 변경 응답 예제: `profileImageUrl: null` → 기본 이미지 URL

## Test plan
- [ ] Swagger UI에서 예제 값 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서화

* API 응답 예제가 업데이트되어 프로필 이미지 URL이 null 대신 기본 이미지로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->