### PR TITLE
test: 토큰 재발급 및 로그아웃 테스트 추가

### DIFF
--- a/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,164 @@
+package com.gotcha.domain.auth.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gotcha._global.exception.GlobalExceptionHandler;
+import com.gotcha._global.util.SecurityUtil;
+import com.gotcha.domain.auth.dto.ReissueRequest;
+import com.gotcha.domain.auth.dto.TokenResponse;
+import com.gotcha.domain.auth.exception.AuthException;
+import com.gotcha.domain.auth.service.AuthService;
+import com.gotcha.domain.user.entity.SocialType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private AuthController authController;
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private SecurityUtil securityUtil;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(converter)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/reissue")
+    class Reissue {
+
+        @Test
+        @DisplayName("유효한 리프레시 토큰으로 새 토큰을 발급받는다")
+        void shouldReissueTokensWithValidRefreshToken() throws Exception {
+            // given
+            ReissueRequest request = new ReissueRequest("valid-refresh-token");
+            TokenResponse response = new TokenResponse(
+                    "new-access-token",
+                    "new-refresh-token",
+                    new TokenResponse.UserResponse(1L, "테스트유저", "test@example.com", SocialType.KAKAO, false)
+            );
+
+            given(authService.reissueToken(anyString())).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/auth/reissue")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+                    .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"))
+                    .andExpect(jsonPath("$.data.user.id").value(1))
+                    .andExpect(jsonPath("$.data.user.isNewUser").value(false));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리프레시 토큰이면 401 에러를 반환한다")
+        void shouldReturn401WhenRefreshTokenNotFound() throws Exception {
+            // given
+            ReissueRequest request = new ReissueRequest("invalid-refresh-token");
+            given(authService.reissueToken(anyString()))
+                    .willThrow(AuthException.refreshTokenNotFound());
+
+            // when & then
+            mockMvc.perform(post("/api/auth/reissue")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("A010"));
+        }
+
+        @Test
+        @DisplayName("만료된 리프레시 토큰이면 401 에러를 반환한다")
+        void shouldReturn401WhenRefreshTokenExpired() throws Exception {
+            // given
+            ReissueRequest request = new ReissueRequest("expired-refresh-token");
+            given(authService.reissueToken(anyString()))
+                    .willThrow(AuthException.refreshTokenExpired());
+
+            // when & then
+            mockMvc.perform(post("/api/auth/reissue")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("A011"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/logout")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃에 성공하면 200을 반환한다")
+        void shouldReturn200OnSuccessfulLogout() throws Exception {
+            // given
+            given(securityUtil.getCurrentUserId()).willReturn(1L);
+            doNothing().when(authService).logout(anyLong());
+
+            // when & then
+            mockMvc.perform(post("/api/auth/logout")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자가 로그아웃하면 401 에러를 반환한다")
+        void shouldReturn401WhenNotAuthenticated() throws Exception {
+            // given
+            given(securityUtil.getCurrentUserId())
+                    .willThrow(AuthException.unauthorized());
+
+            // when & then
+            mockMvc.perform(post("/api/auth/logout")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.error.code").value("A001"));
+        }
+    }
+}

--- a/src/test/java/com/gotcha/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/gotcha/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,181 @@
+package com.gotcha.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.gotcha.domain.auth.dto.TokenResponse;
+import com.gotcha.domain.auth.entity.RefreshToken;
+import com.gotcha.domain.auth.exception.AuthException;
+import com.gotcha.domain.auth.jwt.JwtTokenProvider;
+import com.gotcha.domain.auth.repository.RefreshTokenRepository;
+import com.gotcha.domain.user.entity.SocialType;
+import com.gotcha.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private User testUser;
+    private RefreshToken validRefreshToken;
+    private RefreshToken expiredRefreshToken;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(authService, "refreshTokenValidity", 604800000L); // 7일
+
+        testUser = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("12345")
+                .nickname("테스트유저")
+                .build();
+        ReflectionTestUtils.setField(testUser, "id", 1L);
+
+        validRefreshToken = RefreshToken.builder()
+                .user(testUser)
+                .token("valid-refresh-token")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+
+        expiredRefreshToken = RefreshToken.builder()
+                .user(testUser)
+                .token("expired-refresh-token")
+                .expiresAt(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("reissueToken")
+    class ReissueToken {
+
+        @Test
+        @DisplayName("유효한 리프레시 토큰으로 새 토큰을 발급한다")
+        void shouldReissueTokenWithValidRefreshToken() {
+            // given
+            String refreshTokenValue = "valid-refresh-token";
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+
+            given(refreshTokenRepository.findByToken(refreshTokenValue))
+                    .willReturn(Optional.of(validRefreshToken));
+            given(jwtTokenProvider.generateAccessToken(testUser))
+                    .willReturn(newAccessToken);
+            given(jwtTokenProvider.generateRefreshToken(testUser))
+                    .willReturn(newRefreshToken);
+
+            // when
+            TokenResponse response = authService.reissueToken(refreshTokenValue);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.accessToken()).isEqualTo(newAccessToken);
+            assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
+            assertThat(response.user().id()).isEqualTo(1L);
+            assertThat(response.user().isNewUser()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리프레시 토큰이면 예외를 던진다")
+        void shouldThrowExceptionWhenRefreshTokenNotFound() {
+            // given
+            String invalidToken = "non-existent-token";
+            given(refreshTokenRepository.findByToken(invalidToken))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissueToken(invalidToken))
+                    .isInstanceOf(AuthException.class)
+                    .hasMessageContaining("리프레시 토큰");
+        }
+
+        @Test
+        @DisplayName("만료된 리프레시 토큰이면 삭제 후 예외를 던진다")
+        void shouldDeleteAndThrowExceptionWhenRefreshTokenExpired() {
+            // given
+            String expiredToken = "expired-refresh-token";
+            given(refreshTokenRepository.findByToken(expiredToken))
+                    .willReturn(Optional.of(expiredRefreshToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissueToken(expiredToken))
+                    .isInstanceOf(AuthException.class)
+                    .hasMessageContaining("만료");
+
+            verify(refreshTokenRepository).delete(expiredRefreshToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    class Logout {
+
+        @Test
+        @DisplayName("사용자 ID로 리프레시 토큰을 삭제한다")
+        void shouldDeleteRefreshTokenByUserId() {
+            // given
+            Long userId = 1L;
+
+            // when
+            authService.logout(userId);
+
+            // then
+            verify(refreshTokenRepository).deleteByUserId(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("saveRefreshToken")
+    class SaveRefreshToken {
+
+        @Test
+        @DisplayName("기존 토큰이 있으면 업데이트한다")
+        void shouldUpdateExistingToken() {
+            // given
+            String newToken = "new-refresh-token";
+            given(refreshTokenRepository.findByUser(testUser))
+                    .willReturn(Optional.of(validRefreshToken));
+
+            // when
+            authService.saveRefreshToken(testUser, newToken);
+
+            // then
+            assertThat(validRefreshToken.getToken()).isEqualTo(newToken);
+        }
+
+        @Test
+        @DisplayName("기존 토큰이 없으면 새로 저장한다")
+        void shouldSaveNewTokenWhenNotExists() {
+            // given
+            String newToken = "new-refresh-token";
+            given(refreshTokenRepository.findByUser(testUser))
+                    .willReturn(Optional.empty());
+
+            // when
+            authService.saveRefreshToken(testUser, newToken);
+
+            // then
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
토큰 재발급(reissue) 및 로그아웃(logout) 기능에 대한 단위 테스트 추가

## 추가된 테스트

### AuthServiceTest
| 테스트 | 설명 |
|--------|------|
| reissueToken - 유효한 토큰 | 새 accessToken + refreshToken 발급 |
| reissueToken - 토큰 없음 | A010 예외 발생 |
| reissueToken - 토큰 만료 | A011 예외 발생, 토큰 삭제 |
| logout | 사용자 ID로 리프레시 토큰 삭제 |
| saveRefreshToken - 기존 토큰 | 토큰 업데이트 |
| saveRefreshToken - 새 토큰 | 새 토큰 저장 |

### AuthControllerTest
| 테스트 | 설명 |
|--------|------|
| POST /api/auth/reissue - 성공 | 200 + 새 토큰 반환 |
| POST /api/auth/reissue - 토큰 없음 | 401 + A010 |
| POST /api/auth/reissue - 토큰 만료 | 401 + A011 |
| POST /api/auth/logout - 성공 | 200 |
| POST /api/auth/logout - 미인증 | 401 + A001 |

## Test plan
- [x] `./gradlew test` 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트

* 인증 컨트롤러의 토큰 재발급 및 로그아웃 엔드포인트에 대한 포괄적인 통합 테스트 추가
* 인증 서비스의 토큰 관리 기능(갱신, 저장, 삭제)에 대한 단위 테스트 추가
* 유효한 토큰, 만료된 토큰, 존재하지 않는 토큰 등 다양한 시나리오에 대한 테스트 케이스 구현으로 인증 시스템의 안정성 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->