### PR TITLE
fix: 네이버 OAuth client-authentication-method 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/api/auth/callback/naver"
             authorization-grant-type: authorization_code
-            scope: profile_image, email
+            client-authentication-method: client_secret_post
             client-name: Naver
         provider:
           kakao:


### PR DESCRIPTION
## Summary
- Naver OAuth 설정에 `client_secret_post` 인증 방식 추가
- scope 제거 (네이버는 개발자센터에서 권한 설정)
- 네이버 로그인 "서비스 설정 오류" 문제 해결

## 변경 내용
네이버 OAuth2 설정에서 `client-authentication-method: client_secret_post`가 누락되어 있었습니다. 이 설정이 없으면 네이버 토큰 엔드포인트에서 인증 실패가 발생합니다.

## Test plan
- [ ] 로컬에서 네이버 로그인 테스트
- [ ] 배포 환경에서 네이버 로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Naver OAuth2 인증 설정을 업데이트했습니다. 클라이언트 인증 방식을 개선하여 보안을 강화했습니다.

* **구성 변경**
  * Naver 계정 연동 시 요청하는 정보 범위를 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->