### PR TITLE
fix: /api/dev/** 경로 permitAll 추가

### DIFF
--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/shops/**").permitAll()
                         // Swagger
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api/v3/api-docs/**", "/api/swagger-ui/**", "/api/swagger-ui.html").permitAll()
+                        // Dev API (local/dev 환경에서만 빈 등록됨)
+                        .requestMatchers("/api/dev/**").permitAll()
                         // Authenticated - 사용자
                         .requestMatchers("/api/users/**").authenticated()
                         // Public - 가게 제보 (비회원도 가능)


### PR DESCRIPTION
## Summary
- DevAuthController가 local/dev 환경에서만 빈 등록되지만, SecurityConfig에서 인증을 요구해 접근 불가했던 문제 수정
- `/api/dev/token` 엔드포인트를 인증 없이 사용할 수 있도록 permitAll 추가
- prod 환경에서는 빈 자체가 없어 404 반환 (보안 유지)

## Test plan
- [x] 로컬에서 `/api/dev/token?userId=1` 호출 시 토큰 정상 발급 확인
- [ ] dev 서버 배포 후 Swagger에서 Dev Server 선택하여 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경 API 엔드포인트(`/api/dev/**`)에 대한 접근 권한이 업데이트되었습니다. 보안 설정에 개발 엔드포인트를 위한 새로운 권한 규칙이 추가되어, 개발 단계에서 더욱 유연한 API 접근이 가능해졌습니다. 기존의 공개 및 관리자 규칙은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->