### PR TITLE
fix: 파일 업로드 크기 제한 설정 및 예외 처리 추가

### DIFF
--- a/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
@@ -2,11 +2,13 @@ package com.gotcha._global.exception;
 
 import com.gotcha._global.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import com.gotcha.domain.file.exception.FileErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -44,6 +46,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(
+            MaxUploadSizeExceededException e) {
+        log.warn("File size exceeded: {}", e.getMessage());
+        return ResponseEntity
+                .status(FileErrorCode.FILE_TOO_LARGE.getStatus())
+                .body(ApiResponse.error(FileErrorCode.FILE_TOO_LARGE));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     import: optional:file:.env[.properties]
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
   datasource:
     driver-class-name: org.postgresql.Driver
   jpa:


### PR DESCRIPTION
- application.yml에 multipart 설정 추가 (max-file-size: 20MB)
- GlobalExceptionHandler에 MaxUploadSizeExceededException 핸들러 추가
- Spring 기본값(1MB) 대신 서비스 요구사항(20MB)에 맞게 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 파일 업로드 크기 제한 20MB 설정 및 적용
  * 제한을 초과하는 파일 업로드 시도 시 명확한 오류 메시지 반환

* **버그 수정**
  * 파일 업로드 관련 예외 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->