### PR TITLE
fix: OAuth2 콜백 HTTPS 인식 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,7 @@ spring:
 
 server:
   port: ${PORT:8080}
+  forward-headers-strategy: framework
   servlet:
     encoding:
       charset: UTF-8


### PR DESCRIPTION
## Summary
- GCP 프록시 뒤에서 OAuth2 콜백 URL이 HTTP로 인식되는 문제 해결
- `server.forward-headers-strategy: framework` 설정 추가

## Problem
```
OAuth2AuthenticationException: [authorization_request_not_found]
```

카카오 로그인 후 콜백 시 인증 요청을 찾을 수 없는 에러 발생

### 원인
1. GCP 로드밸런서가 HTTPS → HTTP로 변환하여 Spring에 전달
2. Spring이 `{baseUrl}`을 `http://`로 인식
3. 쿠키가 `Secure=true`로 설정되어 HTTP 콜백에서 전송 안 됨
4. state 쿠키를 못 읽어서 캐시 조회 실패

## Solution
```yaml
server:
  forward-headers-strategy: framework
```

Spring이 `X-Forwarded-Proto` 헤더를 읽어 원래 프로토콜(HTTPS) 인식

## Test
- [ ] 카카오 로그인 테스트
- [ ] 구글 로그인 테스트
- [ ] 네이버 로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 설정이 업데이트되어 프록시 또는 로드 밸런서 환경에서 요청 헤더 처리가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->