### PR TITLE
fix: 탈퇴/로그아웃 시 인증 쿠키 삭제

### DIFF
--- a/src/main/java/com/gotcha/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gotcha/domain/auth/controller/AuthController.java
@@ -8,6 +8,9 @@ import com.gotcha.domain.auth.dto.TokenExchangeResponse;
 import com.gotcha.domain.auth.dto.TokenResponse;
 import com.gotcha.domain.auth.service.AuthService;
 import com.gotcha.domain.auth.service.OAuthTokenCacheService;
+import com.gotcha.domain.auth.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
@@ -35,9 +38,13 @@ public class AuthController implements AuthControllerApi {
 
     @Override
     @PostMapping("/logout")
-    public ApiResponse<Void> logout() {
+    public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
         Long userId = securityUtil.getCurrentUserId();
         authService.logout(userId);
+
+        // 인증 관련 쿠키 삭제 (HttpOnly 쿠키는 Set-Cookie 헤더로만 삭제 가능)
+        CookieUtils.clearAuthCookies(request, response);
+
         return ApiResponse.success(null);
     }
 

--- a/src/main/java/com/gotcha/domain/auth/controller/AuthControllerApi.java
+++ b/src/main/java/com/gotcha/domain/auth/controller/AuthControllerApi.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -83,7 +85,15 @@ public interface AuthControllerApi {
 
     @Operation(
             summary = "로그아웃",
-            description = "리프레시 토큰을 무효화하여 로그아웃합니다",
+            description = """
+                    리프레시 토큰을 무효화하고 인증 관련 쿠키를 삭제합니다.
+
+                    **처리 내역:**
+                    - DB에서 Refresh Token 삭제
+                    - 인증 관련 쿠키 삭제 (Set-Cookie 헤더로 응답)
+
+                    **주의:** 프론트엔드에서 localStorage의 토큰도 삭제해야 합니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -120,7 +130,7 @@ public interface AuthControllerApi {
                     )
             )
     })
-    ApiResponse<Void> logout();
+    ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response);
 
     @Operation(
             summary = "임시 코드로 토큰 교환",

--- a/src/main/java/com/gotcha/domain/auth/util/CookieUtils.java
+++ b/src/main/java/com/gotcha/domain/auth/util/CookieUtils.java
@@ -1,0 +1,60 @@
+package com.gotcha.domain.auth.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+/**
+ * 쿠키 관련 유틸리티 클래스
+ */
+public final class CookieUtils {
+
+    private static final String OAUTH2_STATE_COOKIE_NAME = "oauth2_auth_state";
+    private static final String OAUTH2_REDIRECT_URI_COOKIE_NAME = "oauth2_redirect_uri";
+
+    private CookieUtils() {
+        // 유틸리티 클래스이므로 인스턴스화 방지
+    }
+
+    /**
+     * 인증 관련 모든 쿠키 삭제 (탈퇴, 로그아웃 시 사용)
+     *
+     * @param request  HttpServletRequest (secure 여부 판단용)
+     * @param response HttpServletResponse (쿠키 설정용)
+     */
+    public static void clearAuthCookies(HttpServletRequest request, HttpServletResponse response) {
+        boolean isSecure = isSecureRequest(request);
+
+        // OAuth2 상태 쿠키 삭제
+        deleteCookie(response, OAUTH2_STATE_COOKIE_NAME, isSecure);
+
+        // OAuth2 리다이렉트 URI 쿠키 삭제
+        deleteCookie(response, OAUTH2_REDIRECT_URI_COOKIE_NAME, isSecure);
+    }
+
+    /**
+     * 특정 쿠키 삭제
+     */
+    private static void deleteCookie(HttpServletResponse response, String cookieName, boolean isSecure) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(isSecure)
+                .sameSite("Lax")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /**
+     * 요청이 HTTPS인지 확인 (프록시 뒤에서도 동작하도록 X-Forwarded-Proto 헤더 확인)
+     */
+    private static boolean isSecureRequest(HttpServletRequest request) {
+        if (request.isSecure()) {
+            return true;
+        }
+        String forwardedProto = request.getHeader("X-Forwarded-Proto");
+        return "https".equalsIgnoreCase(forwardedProto);
+    }
+}

--- a/src/main/java/com/gotcha/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.gotcha.domain.user.controller;
 
 import com.gotcha._global.common.ApiResponse;
 import com.gotcha._global.common.PageResponse;
+import com.gotcha.domain.auth.util.CookieUtils;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.favorite.service.FavoriteService;
 import com.gotcha.domain.user.dto.MyShopResponse;
@@ -11,6 +12,8 @@ import com.gotcha.domain.user.dto.UserNicknameResponse;
 import com.gotcha.domain.user.dto.UserResponse;
 import com.gotcha.domain.user.dto.WithdrawalRequest;
 import com.gotcha.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -84,8 +87,16 @@ public class UserController implements UserControllerApi {
 
     @Override
     @DeleteMapping("/me")
-    public ApiResponse<Void> withdraw(@Valid @RequestBody WithdrawalRequest request) {
+    public ApiResponse<Void> withdraw(
+            @Valid @RequestBody WithdrawalRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
+    ) {
         userService.withdraw(request);
+
+        // 인증 관련 쿠키 삭제 (HttpOnly 쿠키는 Set-Cookie 헤더로만 삭제 가능)
+        CookieUtils.clearAuthCookies(httpRequest, httpResponse);
+
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -550,7 +552,16 @@ public interface UserControllerApi {
 
     @Operation(
             summary = "회원 탈퇴",
-            description = "회원 탈퇴 및 설문 제출. 탈퇴 시 Refresh Token이 삭제되고 사용자는 soft delete됩니다.",
+            description = """
+                    회원 탈퇴 및 설문 제출.
+
+                    **처리 내역:**
+                    - Refresh Token 삭제
+                    - 인증 관련 쿠키 삭제 (Set-Cookie 헤더로 응답)
+                    - 사용자 soft delete
+
+                    **주의:** 탈퇴 후 프론트엔드에서 localStorage의 토큰도 삭제해야 합니다.
+                    """,
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -620,5 +631,9 @@ public interface UserControllerApi {
                     )
             )
     })
-    ApiResponse<Void> withdraw(@Valid @RequestBody WithdrawalRequest request);
+    ApiResponse<Void> withdraw(
+            @Valid @RequestBody WithdrawalRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse
+    );
 }

--- a/src/test/java/com/gotcha/domain/auth/util/CookieUtilsTest.java
+++ b/src/test/java/com/gotcha/domain/auth/util/CookieUtilsTest.java
@@ -1,0 +1,131 @@
+package com.gotcha.domain.auth.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class CookieUtilsTest {
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Nested
+    @DisplayName("clearAuthCookies")
+    class ClearAuthCookies {
+
+        @Test
+        @DisplayName("HTTP 요청 시 인증 관련 쿠키를 삭제한다 (secure=false)")
+        void shouldClearAuthCookiesForHttpRequest() {
+            // given
+            request.setScheme("http");
+            request.setSecure(false);
+
+            // when
+            CookieUtils.clearAuthCookies(request, response);
+
+            // then
+            Collection<String> setCookieHeaders = response.getHeaders(HttpHeaders.SET_COOKIE);
+            assertThat(setCookieHeaders).hasSize(2);
+
+            // oauth2_auth_state 쿠키 삭제 확인
+            boolean hasStateCookie = setCookieHeaders.stream()
+                    .anyMatch(cookie -> cookie.contains("oauth2_auth_state=")
+                            && cookie.contains("Max-Age=0"));
+            assertThat(hasStateCookie).isTrue();
+
+            // oauth2_redirect_uri 쿠키 삭제 확인
+            boolean hasRedirectCookie = setCookieHeaders.stream()
+                    .anyMatch(cookie -> cookie.contains("oauth2_redirect_uri=")
+                            && cookie.contains("Max-Age=0"));
+            assertThat(hasRedirectCookie).isTrue();
+        }
+
+        @Test
+        @DisplayName("HTTPS 요청 시 Secure 속성이 포함된 쿠키를 삭제한다")
+        void shouldClearAuthCookiesWithSecureForHttpsRequest() {
+            // given
+            request.setScheme("https");
+            request.setSecure(true);
+
+            // when
+            CookieUtils.clearAuthCookies(request, response);
+
+            // then
+            Collection<String> setCookieHeaders = response.getHeaders(HttpHeaders.SET_COOKIE);
+            assertThat(setCookieHeaders).hasSize(2);
+
+            // Secure 속성 확인
+            boolean allSecure = setCookieHeaders.stream()
+                    .allMatch(cookie -> cookie.contains("Secure"));
+            assertThat(allSecure).isTrue();
+        }
+
+        @Test
+        @DisplayName("프록시 뒤에서 X-Forwarded-Proto 헤더로 HTTPS 판단")
+        void shouldDetectHttpsFromForwardedProtoHeader() {
+            // given
+            request.setScheme("http");
+            request.setSecure(false);
+            request.addHeader("X-Forwarded-Proto", "https");
+
+            // when
+            CookieUtils.clearAuthCookies(request, response);
+
+            // then
+            Collection<String> setCookieHeaders = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+            // Secure 속성이 포함되어야 함
+            boolean allSecure = setCookieHeaders.stream()
+                    .allMatch(cookie -> cookie.contains("Secure"));
+            assertThat(allSecure).isTrue();
+        }
+
+        @Test
+        @DisplayName("쿠키에 HttpOnly, SameSite=Lax 속성이 포함된다")
+        void shouldIncludeSecurityAttributesInCookies() {
+            // given
+            request.setSecure(true);
+
+            // when
+            CookieUtils.clearAuthCookies(request, response);
+
+            // then
+            Collection<String> setCookieHeaders = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+            boolean allHttpOnly = setCookieHeaders.stream()
+                    .allMatch(cookie -> cookie.contains("HttpOnly"));
+            assertThat(allHttpOnly).isTrue();
+
+            boolean allSameSiteLax = setCookieHeaders.stream()
+                    .allMatch(cookie -> cookie.contains("SameSite=Lax"));
+            assertThat(allSameSiteLax).isTrue();
+        }
+
+        @Test
+        @DisplayName("쿠키 경로가 /로 설정된다")
+        void shouldSetCookiePathToRoot() {
+            // when
+            CookieUtils.clearAuthCookies(request, response);
+
+            // then
+            Collection<String> setCookieHeaders = response.getHeaders(HttpHeaders.SET_COOKIE);
+
+            boolean allPathRoot = setCookieHeaders.stream()
+                    .allMatch(cookie -> cookie.contains("Path=/"));
+            assertThat(allPathRoot).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 탈퇴/로그아웃 시 인증 관련 쿠키를 서버에서 삭제
- HttpOnly 쿠키는 JavaScript로 삭제할 수 없으므로 Set-Cookie 헤더로 삭제

## 문제 상황
- 탈퇴 후 재로그인 시 "로그인이 필요합니다" 에러 발생
- OAuth2 쿠키가 브라우저에 남아있어 인증 플로우에 영향

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `CookieUtils.java` | 쿠키 삭제 유틸리티 클래스 (신규) |
| `CookieUtilsTest.java` | 단위 테스트 5개 (신규) |
| `UserController.java` | 탈퇴 시 쿠키 삭제 추가 |
| `AuthController.java` | 로그아웃 시 쿠키 삭제 추가 |
| `*ControllerApi.java` | Swagger 문서 업데이트 |

## 삭제 대상 쿠키
| 쿠키 | 용도 |
|------|------|
| `oauth2_auth_state` | OAuth2 인가 요청 상태 |
| `oauth2_redirect_uri` | 리다이렉트 URI |

## 탈퇴 시 토큰 처리
| 항목 | 처리 방식 |
|------|----------|
| Refresh Token | DB에서 삭제 ✅ |
| OAuth2 쿠키 | Set-Cookie로 삭제 ✅ |
| Access Token | JWT (프론트엔드에서 localStorage 삭제 필요) |

## Test plan
- [x] CookieUtilsTest 단위 테스트 5개 통과
- [x] 컴파일 성공
- [x] dev 브랜치 리베이스 완료
- [ ] dev 환경에서 탈퇴 → 재로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증 쿠키 관리 유틸리티 추가로 로그아웃 및 회원 탈퇴 시 쿠키를 안전하게 삭제
  * HTTP/HTTPS 및 프록시 환경을 감지해 적절한 보안 속성으로 쿠키 처리

* **Tests**
  * 쿠키 삭제 동작에 대한 포괄적 테스트 추가(HTTP/HTTPS, X-Forwarded-Proto, 속성 검증)

* **Chores**
  * 로그아웃·회원 탈퇴 엔드포인트에 쿠키 정리 동작 통합하여 클라이언트 상태 일관성 보장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->