### PR TITLE
refactor: OAuth2 토큰 전달 방식을 쿠키에서 URL 파라미터로 변경

### DIFF
--- a/src/main/java/com/gotcha/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gotcha/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.gotcha.domain.auth.controller;
 import com.gotcha._global.common.ApiResponse;
 import com.gotcha._global.util.SecurityUtil;
 import com.gotcha.domain.auth.dto.ReissueRequest;
+import com.gotcha.domain.auth.dto.TokenExchangeRequest;
 import com.gotcha.domain.auth.dto.TokenExchangeResponse;
 import com.gotcha.domain.auth.dto.TokenResponse;
 import com.gotcha.domain.auth.service.AuthService;
@@ -50,9 +51,9 @@ public class AuthController implements AuthControllerApi {
     @Override
     @PostMapping("/token")
     public ApiResponse<TokenExchangeResponse> exchangeToken(
-            HttpServletRequest request, HttpServletResponse response) {
-        // 쿠키 기반으로 토큰 교환 (code 파라미터 불필요)
-        TokenExchangeResponse tokenResponse = authService.exchangeToken(request, response);
+            @Valid @RequestBody TokenExchangeRequest request) {
+        // body의 code를 복호화하여 토큰 반환 (쿠키 불필요 - cross-site 지원)
+        TokenExchangeResponse tokenResponse = authService.exchangeToken(request.code());
         return ApiResponse.success(tokenResponse);
     }
 

--- a/src/main/java/com/gotcha/domain/auth/controller/AuthControllerApi.java
+++ b/src/main/java/com/gotcha/domain/auth/controller/AuthControllerApi.java
@@ -2,6 +2,7 @@ package com.gotcha.domain.auth.controller;
 
 import com.gotcha._global.common.ApiResponse;
 import com.gotcha.domain.auth.dto.ReissueRequest;
+import com.gotcha.domain.auth.dto.TokenExchangeRequest;
 import com.gotcha.domain.auth.dto.TokenExchangeResponse;
 import com.gotcha.domain.auth.dto.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -132,22 +133,21 @@ public interface AuthControllerApi {
     ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response);
 
     @Operation(
-            summary = "쿠키 기반 토큰 교환",
+            summary = "토큰 교환",
             description = """
-                    OAuth 로그인 완료 후 쿠키에 저장된 토큰 데이터를 실제 토큰으로 교환합니다.
+                    OAuth 로그인 완료 후 URL 파라미터로 받은 암호화된 코드를 실제 토큰으로 교환합니다.
 
                     **플로우:**
-                    1. 소셜 로그인 완료 → 토큰이 암호화된 쿠키에 저장됨
-                    2. 프론트엔드가 이 API를 호출하면 쿠키에서 토큰 추출
-                    3. 쿠키 자동 삭제 후 토큰 반환
+                    1. 소셜 로그인 완료 → 암호화된 토큰이 URL 파라미터(code)로 전달됨
+                    2. 프론트엔드가 code를 body에 담아 이 API 호출
+                    3. 서버가 code를 복호화하여 토큰 반환
 
                     **보안:**
-                    - 쿠키는 30초 후 자동 만료됩니다
-                    - 1회 사용 후 즉시 삭제됩니다
-                    - HttpOnly, Secure, SameSite=Lax 설정
+                    - 토큰은 AES-GCM으로 암호화되어 있습니다
+                    - 서버의 암호화 키 없이는 복호화 불가능합니다
 
-                    **분산 환경 지원:**
-                    - 쿠키 기반으로 동작하여 다중 인스턴스에서도 안정적
+                    **Cross-site 지원:**
+                    - 쿠키를 사용하지 않아 cross-origin 환경에서도 동작합니다
                     """
     )
     @ApiResponses({
@@ -174,7 +174,7 @@ public interface AuthControllerApi {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "A013 - 유효하지 않은 토큰 쿠키",
+                                    name = "A013 - 유효하지 않은 코드",
                                     value = """
                                             {
                                               "success": false,
@@ -188,7 +188,7 @@ public interface AuthControllerApi {
                     )
             )
     })
-    ApiResponse<TokenExchangeResponse> exchangeToken(HttpServletRequest request, HttpServletResponse response);
+    ApiResponse<TokenExchangeResponse> exchangeToken(@Valid @RequestBody TokenExchangeRequest request);
 
     @Operation(
             summary = "[테스트용] 임시 코드 생성",

--- a/src/main/java/com/gotcha/domain/auth/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/gotcha/domain/auth/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -4,11 +4,7 @@ import com.gotcha.domain.auth.exception.AuthErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
@@ -41,10 +37,8 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         }
         cookieRepository.removeRedirectUriCookie(response);
 
-        String encodedMessage = URLEncoder.encode(errorCode.getMessage(), StandardCharsets.UTF_8);
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-                .queryParam("code", errorCode.getCode())
-                .queryParam("message", encodedMessage)
+                .queryParam("error", errorCode.getCode())
                 .build()
                 .toUriString();
 

--- a/src/main/java/com/gotcha/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gotcha/domain/auth/service/AuthService.java
@@ -8,8 +8,6 @@ import com.gotcha.domain.auth.jwt.JwtTokenProvider;
 import com.gotcha.domain.auth.repository.RefreshTokenRepository;
 import com.gotcha.domain.auth.service.OAuthTokenCookieService.TokenData;
 import com.gotcha.domain.user.entity.User;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -72,15 +70,14 @@ public class AuthService {
     }
 
     /**
-     * OAuth 임시 코드를 토큰으로 교환 (쿠키 기반)
+     * OAuth 암호화된 코드를 토큰으로 교환
      *
-     * @param request  HTTP 요청 (쿠키에서 토큰 읽기)
-     * @param response HTTP 응답 (쿠키 삭제)
+     * @param encryptedCode 암호화된 토큰 코드 (URL 파라미터로 전달받은 값)
      * @return 토큰 응답
-     * @throws AuthException 유효하지 않거나 만료된 코드인 경우
+     * @throws AuthException 유효하지 않거나 복호화 실패한 코드인 경우
      */
-    public TokenExchangeResponse exchangeToken(HttpServletRequest request, HttpServletResponse response) {
-        TokenData tokenData = oAuthTokenCacheService.exchangeCode(request, response);
+    public TokenExchangeResponse exchangeToken(String encryptedCode) {
+        TokenData tokenData = oAuthTokenCacheService.decryptTokens(encryptedCode);
         if (tokenData == null) {
             throw AuthException.invalidAuthCode();
         }

--- a/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
@@ -1,6 +1,5 @@
 package com.gotcha.domain.auth.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -14,13 +13,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gotcha._global.exception.GlobalExceptionHandler;
 import com.gotcha._global.util.SecurityUtil;
 import com.gotcha.domain.auth.dto.ReissueRequest;
+import com.gotcha.domain.auth.dto.TokenExchangeRequest;
 import com.gotcha.domain.auth.dto.TokenExchangeResponse;
 import com.gotcha.domain.auth.dto.TokenResponse;
 import com.gotcha.domain.auth.exception.AuthException;
 import com.gotcha.domain.auth.service.AuthService;
 import com.gotcha.domain.user.entity.SocialType;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -171,21 +169,22 @@ class AuthControllerTest {
     class ExchangeToken {
 
         @Test
-        @DisplayName("유효한 쿠키로 토큰을 교환한다")
-        void shouldExchangeTokenWithValidCookie() throws Exception {
+        @DisplayName("유효한 코드로 토큰을 교환한다")
+        void shouldExchangeTokenWithValidCode() throws Exception {
             // given
+            TokenExchangeRequest request = new TokenExchangeRequest("valid-encrypted-code");
             TokenExchangeResponse response = TokenExchangeResponse.of(
                     "new-access-token",
                     "new-refresh-token",
                     true
             );
 
-            given(authService.exchangeToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
-                    .willReturn(response);
+            given(authService.exchangeToken(anyString())).willReturn(response);
 
             // when & then
             mockMvc.perform(post("/api/auth/token")
-                            .contentType(MediaType.APPLICATION_JSON))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -198,37 +197,54 @@ class AuthControllerTest {
         @DisplayName("기존 사용자인 경우 isNewUser가 false")
         void shouldReturnIsNewUserFalseForExistingUser() throws Exception {
             // given
+            TokenExchangeRequest request = new TokenExchangeRequest("valid-encrypted-code");
             TokenExchangeResponse response = TokenExchangeResponse.of(
                     "access-token",
                     "refresh-token",
                     false
             );
 
-            given(authService.exchangeToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
-                    .willReturn(response);
+            given(authService.exchangeToken(anyString())).willReturn(response);
 
             // when & then
             mockMvc.perform(post("/api/auth/token")
-                            .contentType(MediaType.APPLICATION_JSON))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.isNewUser").value(false));
         }
 
         @Test
-        @DisplayName("유효하지 않은 쿠키이면 400 에러를 반환한다")
-        void shouldReturn400WithInvalidCookie() throws Exception {
+        @DisplayName("유효하지 않은 코드이면 400 에러를 반환한다")
+        void shouldReturn400WithInvalidCode() throws Exception {
             // given
-            given(authService.exchangeToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            TokenExchangeRequest request = new TokenExchangeRequest("invalid-code");
+            given(authService.exchangeToken(anyString()))
                     .willThrow(AuthException.invalidAuthCode());
 
             // when & then
             mockMvc.perform(post("/api/auth/token")
-                            .contentType(MediaType.APPLICATION_JSON))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.error.code").value("A013"));
+        }
+
+        @Test
+        @DisplayName("code가 없으면 400 에러를 반환한다")
+        void shouldReturn400WhenCodeIsMissing() throws Exception {
+            // given
+            String emptyRequest = "{}";
+
+            // when & then
+            mockMvc.perform(post("/api/auth/token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(emptyRequest))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/gotcha/domain/auth/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/gotcha/domain/auth/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -8,9 +8,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import com.gotcha.domain.auth.jwt.JwtTokenProvider;
 import com.gotcha.domain.auth.service.AuthService;
 import com.gotcha.domain.auth.service.OAuthTokenCookieService;
@@ -77,8 +74,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(anyString(), anyString(), anyBoolean(),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(anyString(), anyString(), anyBoolean()))
                     .willReturn(tempCode);
 
             // when
@@ -92,8 +88,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             assertThat(redirectUrl).doesNotContain("accessToken=");
             assertThat(redirectUrl).doesNotContain("refreshToken=");
             verify(authService).saveRefreshToken(any(User.class), eq("refresh-token"));
-            verify(oAuthTokenCacheService).storeTokens(eq("access-token"), eq("refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class));
+            verify(oAuthTokenCacheService).encryptTokens(eq("access-token"), eq("refresh-token"), eq(true));
         }
     }
 
@@ -112,8 +107,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(anyString(), anyString(), anyBoolean(),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(anyString(), anyString(), anyBoolean()))
                     .willReturn(tempCode);
 
             // when
@@ -127,8 +121,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             assertThat(redirectUrl).doesNotContain("accessToken=");
             assertThat(redirectUrl).doesNotContain("refreshToken=");
             verify(authService).saveRefreshToken(any(User.class), eq("refresh-token"));
-            verify(oAuthTokenCacheService).storeTokens(eq("access-token"), eq("refresh-token"), eq(false),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class));
+            verify(oAuthTokenCacheService).encryptTokens(eq("access-token"), eq("refresh-token"), eq(false));
         }
     }
 
@@ -147,8 +140,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("kakao-access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("kakao-refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("kakao-access-token"), eq("kakao-refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("kakao-access-token"), eq("kakao-refresh-token"), eq(true)))
                     .willReturn(tempCode);
 
             // when
@@ -172,8 +164,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("google-access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("google-refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("google-access-token"), eq("google-refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("google-access-token"), eq("google-refresh-token"), eq(true)))
                     .willReturn(tempCode);
 
             // when
@@ -197,8 +188,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("naver-access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("naver-refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("naver-access-token"), eq("naver-refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("naver-access-token"), eq("naver-refresh-token"), eq(true)))
                     .willReturn(tempCode);
 
             // when
@@ -227,8 +217,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("access-token"), eq("refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("access-token"), eq("refresh-token"), eq(true)))
                     .willReturn(tempCode);
 
             // when
@@ -258,8 +247,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("access-token"), eq("refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("access-token"), eq("refresh-token"), eq(true)))
                     .willReturn(tempCode);
             given(cookieRepository.getRedirectUriFromCookie(request)).willReturn(customRedirectUri);
 
@@ -285,8 +273,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("access-token"), eq("refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("access-token"), eq("refresh-token"), eq(true)))
                     .willReturn(tempCode);
             given(cookieRepository.getRedirectUriFromCookie(request)).willReturn(null);
 
@@ -311,8 +298,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
             given(authentication.getPrincipal()).willReturn(oAuth2User);
             given(jwtTokenProvider.generateAccessToken(any(User.class))).willReturn("access-token");
             given(jwtTokenProvider.generateRefreshToken(any(User.class))).willReturn("refresh-token");
-            given(oAuthTokenCacheService.storeTokens(eq("access-token"), eq("refresh-token"), eq(true),
-                    any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            given(oAuthTokenCacheService.encryptTokens(eq("access-token"), eq("refresh-token"), eq(true)))
                     .willReturn(tempCode);
             given(cookieRepository.getRedirectUriFromCookie(request)).willReturn("   ");
 


### PR DESCRIPTION
## Summary
- Cross-site 환경에서 SameSite 쿠키 정책으로 인한 토큰 교환 실패 문제 해결
- 쿠키 대신 URL 파라미터로 암호화된 토큰 코드 전달

## Changes
- `OAuthTokenCookieService`: `encryptTokens()`, `decryptTokens()` 메서드 추가
- `OAuth2AuthenticationSuccessHandler`: 쿠키 대신 URL 파라미터로 암호화된 code 전달
- `AuthController`: `TokenExchangeRequest` body로 code 수신
- `AuthService`: `decryptTokens()`로 복호화 처리
- 관련 테스트 코드 수정

## 플로우 변경
```
기존: OAuth 성공 → 쿠키에 토큰 저장 → /api/auth/token (쿠키에서 읽기)
      ❌ cross-site에서 쿠키 전송 불가 (SameSite=Lax)

변경: OAuth 성공 → URL에 code 파라미터 → /api/auth/token (body에서 code 받아 복호화)
      ✅ cross-site에서도 동작
```

## Test plan
- [x] OAuth2AuthenticationSuccessHandlerTest 통과
- [x] AuthControllerTest 통과
- [x] AuthServiceTest 통과
- [ ] 실제 소셜 로그인 테스트 (카카오/구글/네이버)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 크로스 사이트 인증 지원: 쿠키에 의존하지 않는 새로운 암호화된 코드 기반 토큰 교환 방식 구현

* **개선사항**
  * 인증 프로세스 간소화 및 보안 강화를 위한 토큰 처리 메커니즘 개선
  * 토큰 암호화 및 복호화 기능 확대로 더욱 안전한 데이터 전달 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->