### PR TITLE
fix: 회원 탈퇴 시 FK 제약조건 위반 에러 수정

### DIFF
--- a/src/main/java/com/gotcha/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/gotcha/domain/review/repository/ReviewLikeRepository.java
@@ -19,6 +19,14 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     @Query("DELETE FROM ReviewLike rl WHERE rl.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 
+    /**
+     * 특정 리뷰들에 대한 모든 좋아요 삭제 (회원 탈퇴 시 사용)
+     * @param reviewIds 삭제할 리뷰 ID 목록
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ReviewLike rl WHERE rl.review.id IN :reviewIds")
+    void deleteAllByReviewIdIn(@Param("reviewIds") List<Long> reviewIds);
+
     boolean existsByUserIdAndReviewId(Long currentUserId, Long reviewId);
 
     /**

--- a/src/test/java/com/gotcha/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/gotcha/domain/user/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import com.gotcha.domain.file.service.FileStorageService;
 import com.gotcha.domain.review.entity.Review;
 import com.gotcha.domain.review.entity.ReviewImage;
 import com.gotcha.domain.review.repository.ReviewImageRepository;
+import com.gotcha.domain.review.repository.ReviewLikeRepository;
 import com.gotcha.domain.review.repository.ReviewRepository;
 import com.gotcha.domain.shop.entity.Shop;
 import com.gotcha.domain.user.dto.UserResponse;
@@ -24,6 +25,7 @@ import com.gotcha.domain.user.entity.User;
 import com.gotcha.domain.user.entity.WithdrawalReason;
 import com.gotcha.domain.user.entity.WithdrawalSurvey;
 import com.gotcha.domain.user.exception.UserException;
+import com.gotcha.domain.user.repository.UserPermissionRepository;
 import com.gotcha.domain.user.repository.UserRepository;
 import com.gotcha.domain.user.repository.WithdrawalSurveyRepository;
 import java.util.Collections;
@@ -47,6 +49,9 @@ class UserServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private UserPermissionRepository userPermissionRepository;
+
+    @Mock
     private WithdrawalSurveyRepository withdrawalSurveyRepository;
 
     @Mock
@@ -60,6 +65,9 @@ class UserServiceTest {
 
     @Mock
     private ReviewImageRepository reviewImageRepository;
+
+    @Mock
+    private ReviewLikeRepository reviewLikeRepository;
 
     @Mock
     private CommentRepository commentRepository;
@@ -217,8 +225,10 @@ class UserServiceTest {
 
             // then - 데이터 삭제 검증
             verify(favoriteRepository).deleteByUserId(testUser.getId());
+            verify(reviewLikeRepository).deleteByUserId(testUser.getId());
             verify(reviewRepository).deleteByUserId(testUser.getId());
             verify(commentRepository).deleteByUserId(testUser.getId());
+            verify(userPermissionRepository).deleteByUserId(testUser.getId());
             verify(refreshTokenRepository).deleteByUserId(testUser.getId());
 
             // then - soft delete 및 마스킹 검증
@@ -310,6 +320,9 @@ class UserServiceTest {
 
             // then - DB 이미지 삭제 검증
             verify(reviewImageRepository).deleteAllByReviewIdIn(List.of(100L));
+
+            // then - 리뷰 좋아요 삭제 검증
+            verify(reviewLikeRepository).deleteAllByReviewIdIn(List.of(100L));
 
             // then - 리뷰 삭제 검증
             verify(reviewRepository).deleteByUserId(testUser.getId());


### PR DESCRIPTION
## Summary

- 회원 탈퇴(`DELETE /api/users/me`) 시 간헐적으로 500 에러 발생하는 문제 수정
- 원인: FK 제약조건이 있는 연관 데이터 삭제 누락
  - `ReviewLike`: 사용자가 누른 좋아요 / 사용자 리뷰에 달린 좋아요
  - `UserPermission`: 권한 동의 기록

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `ReviewLikeRepository.java` | `deleteAllByReviewIdIn` 메서드 추가 |
| `UserService.java` | 삭제 로직 추가 (ReviewLike, UserPermission) |
| `UserServiceTest.java` | mock 및 검증 추가 |

## 삭제 순서 (수정 후)

```
1. 탈퇴 설문 저장
2. 찜 목록 삭제
3. 사용자가 누른 리뷰 좋아요 삭제 ← 신규
4. 리뷰 이미지 + 사용자 리뷰에 달린 좋아요 삭제 ← 신규
5. 리뷰 삭제
6. 댓글 삭제
7. 권한 동의 기록 삭제 ← 신규
8. RefreshToken 삭제
9. 사용자 soft delete
```

## Test plan

- [x] `./gradlew build -x test` 성공
- [x] `UserServiceTest` withdraw 관련 테스트 5개 통과
- [ ] 리뷰 좋아요가 있는 사용자로 탈퇴 테스트 (dev 환경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 회원 탈퇴 시 사용자의 좋아요 데이터를 포함한 모든 관련 정보가 시스템에서 완전히 제거되도록 개선되었습니다.
  * 계정 삭제 프로세스에서 관련 권한 정보가 함께 정리되어 데이터 정합성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->