### PR TITLE
fix: ReviewImageRepository delete 메서드에 @Modifying 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/gotcha/domain/review/repository/ReviewImageRepository.java
@@ -3,6 +3,7 @@ package com.gotcha.domain.review.repository;
 import com.gotcha.domain.review.entity.ReviewImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,13 +16,17 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
     List<ReviewImage> findAllByReviewIdInOrderByReviewIdAscDisplayOrderAsc(List<Long> reviewIds);
 
     // Review 삭제 시 연관 이미지 삭제
-    void deleteAllByReviewId(Long reviewId);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ReviewImage ri WHERE ri.review.id = :reviewId")
+    void deleteAllByReviewId(@Param("reviewId") Long reviewId);
 
     // 이미지 개수 카운트
     int countByReviewId(Long reviewId);
 
     // 여러 Review의 이미지 일괄 삭제
-    void deleteAllByReviewIdIn(List<Long> reviewIds);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ReviewImage ri WHERE ri.review.id IN :reviewIds")
+    void deleteAllByReviewIdIn(@Param("reviewIds") List<Long> reviewIds);
 
     // 특정 가게의 전체 리뷰 이미지 개수
     @Query("SELECT COUNT(ri) FROM ReviewImage ri WHERE ri.review.shop.id = :shopId")


### PR DESCRIPTION
## Summary
- 회원 탈퇴 시 `review_images` FK 제약조건 위반 에러 수정
- `deleteAllByReviewId`와 `deleteAllByReviewIdIn`에 `@Modifying` + `@Query` 어노테이션 추가
- `clearAutomatically = true`로 영속성 컨텍스트 즉시 동기화

## 원인 분석
```
PSQLException: ERROR: update or delete on table "reviews" violates foreign key constraint 
"fk3aayo5bjciyemf3bvvt987hkr" on table "review_images"
```

Spring Data JPA의 **Derived delete method** (`deleteAllByReviewIdIn`)는:
1. 먼저 SELECT로 엔티티 조회
2. 각 엔티티를 개별 DELETE

`@Modifying` 없이는 트랜잭션 내에서 즉시 flush되지 않아, 리뷰 삭제 시점에 이미지가 아직 DB에 남아 FK 위반 발생

## Test plan
- [ ] 주황뽑기#9071 계정으로 회원 탈퇴 테스트
- [ ] 리뷰가 있는 유저의 탈퇴 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced reliability of review image deletion operations by implementing explicit database query statements with automatic cache management.
  * Improved database query handling for batch operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->