### PR TITLE
feat: 구글 소셜 로그인 탈퇴 시 연동 해제 기능 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/gotcha/domain/auth/oauth2/CustomOAuth2UserService.java
@@ -84,6 +84,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 })
                 .orElseGet(() -> createNewUser(userInfo, socialType));
 
+        // 구글 로그인인 경우 OAuth2 access_token 저장 (탈퇴 시 연동 해제용)
+        if (socialType == SocialType.GOOGLE) {
+            String oauthAccessToken = userRequest.getAccessToken().getTokenValue();
+            user.updateOAuthAccessToken(oauthAccessToken);
+            log.debug("Google OAuth access token saved - userId: {}", user.getId());
+        }
+
         return new CustomOAuth2User(user, oauth2User.getAttributes(), isNewUser);
     }
 

--- a/src/main/java/com/gotcha/domain/user/entity/User.java
+++ b/src/main/java/com/gotcha/domain/user/entity/User.java
@@ -47,6 +47,13 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "boolean default false")
     private Boolean isDeleted = false;
 
+    /**
+     * OAuth2 Access Token (구글 연동 해제용)
+     * 로그인 시 저장, 탈퇴 시 revoke API 호출에 사용
+     */
+    @Column(name = "oauth_access_token", columnDefinition = "TEXT")
+    private String oauthAccessToken;
+
     @Builder
     public User(SocialType socialType, String socialId, String nickname,
                 String email, String profileImageUrl) {
@@ -74,10 +81,15 @@ public class User extends BaseTimeEntity {
         this.lastLoginAt = LocalDateTime.now();
     }
 
+    public void updateOAuthAccessToken(String oauthAccessToken) {
+        this.oauthAccessToken = oauthAccessToken;
+    }
+
     /**
      * 회원 탈퇴 처리
      * - 소셜 연동 정보 제거 (재가입 허용)
      * - 개인정보 마스킹 (닉네임, 이메일, 프로필 이미지)
+     * - OAuth 토큰 제거
      * - soft delete 플래그 설정
      */
     public void delete() {
@@ -86,6 +98,7 @@ public class User extends BaseTimeEntity {
         this.nickname = "탈퇴한 사용자_" + this.id;
         this.email = null;
         this.profileImageUrl = null;
+        this.oauthAccessToken = null;
         this.isDeleted = true;
     }
 }


### PR DESCRIPTION
## Summary
- 구글 소셜 로그인 사용자가 회원 탈퇴 시 구글 연동이 자동으로 해제되도록 구현
- 기존 카카오는 Admin Key 방식으로 구현되어 있었으나, 구글은 Token Revoke 방식 필요

## Changes
- `User.java`: `oauthAccessToken` 필드 추가 (TEXT 타입)
- `CustomOAuth2UserService.java`: 구글 로그인 시 OAuth2 access_token DB 저장
- `SocialUnlinkService.java`: 구글 revoke API 호출 로직 추가
- `SocialUnlinkServiceTest.java`: 구글 연동 해제 테스트 4개 추가

## How it works
```
[구글 로그인]
1. 사용자가 구글 로그인
2. 구글에서 받은 access_token을 users.oauth_access_token에 저장

[회원 탈퇴]
1. UserService.withdraw() 호출
2. SocialUnlinkService.unlinkGoogle() 호출
3. POST https://oauth2.googleapis.com/revoke?token={저장된 토큰}
4. revoke 성공/실패 상관없이 탈퇴 진행 (UX 우선)
```

## DB Migration
```sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS oauth_access_token TEXT;
```
> 이미 dev DB에 적용 완료

## Test plan
- [x] SocialUnlinkServiceTest 통과
- [x] CustomOAuth2UserServiceTest 통과
- [ ] 실제 구글 로그인 → DB 토큰 저장 확인
- [ ] 회원 탈퇴 → 구글 연동 해제 확인 (myaccount.google.com/permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google OAuth 로그인 시 접근 토큰을 안전하게 저장하는 기능 추가

* **개선 사항**
  * Google 계정 연동 해제 시 OAuth 토큰을 Google에 반환하여 보안 강화
  * 토큰 반환 실패 시에도 계정 연동 해제가 정상 완료되도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->