### PR TITLE
feat: Optimize t3.micro - limit Docker memory/cpu, JVM tuning

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -69,7 +69,7 @@ jobs:
               --memory-swap="1g" \
               --cpus="1.5" \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e JAVA_OPTS="-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200" \
+              -e JAVA_TOOL_OPTIONS="-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200" \
               -e SPRING_DATASOURCE_URL="${{ secrets.DB_URL_PROD }}" \
               -e SPRING_DATASOURCE_USERNAME="${{ secrets.DB_USERNAME_PROD }}" \
               -e SPRING_DATASOURCE_PASSWORD="${{ secrets.DB_PASSWORD_PROD }}" \


### PR DESCRIPTION
## Summary
AWS instance t3.micro (1GB RAM) 환경에서 안정적인 운영을 위한 Docker container memory/CPU 제한 및 JVM tuning 추가

## Problem
- **현재 상황**: Docker container에 memory/CPU 제한 없음
- **위험**: Spring Boot가 system 전체 memory를 소진하면 OOM Killer가 전체 server를 다운시킴
- **t3.micro spec**: 1GB RAM, 2 vCPU
- **예상 memory 사용량**: Spring Boot ~400-600MB + OS/Nginx/Docker ~300MB = 위험 구간

## Solution

### Docker Container 제한 추가
```yaml
  --memory="700m"         # Container 최대 memory
  --memory-swap="1g"      # Memory + swap 합계
  --cpus="1.5"           # CPU 사용량 제한
```

<JVM Heap Tuning>

  -e JAVA_OPTS="-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"

  설정 의미:
  - -Xms256m: 초기 heap size 256MB
  - -Xmx512m: 최대 heap size 512MB (Docker 700MB 제한 내 안전 마진 확보)
  - -XX:+UseG1GC: G1 Garbage Collector 사용 (저메모리 환경 최적화)
  - -XX:MaxGCPauseMillis=200: GC pause time 최대 200ms

<Before (제한 없음)>
  - Memory 초과 시 전체 system down
  - 예측 불가능한 OOM Killer 작동
  - 수동 개입 필요
  - Nginx, OS까지 영향

<After (제한 적용)>
  - Memory 초과 시 container만 restart
  - 예측 가능한 동작
  - 자동 복구 (--restart unless-stopped)
  - System 안정성 확보
  - OS/Nginx는 정상 작동 유지

<Memory 구조>
  Total 1GB:
  ├─ OS + Nginx + Docker daemon: ~300MB
  ├─ Spring Boot container: 최대 700MB (제한됨)
  └─ Safety margin: ~0MB (tight하지만 안전)

<예상 성능>
  - 정상 traffic: 영향 없음 (512MB heap으로 충분)
  - 높은 traffic: GC 빈도 약간 증가 가능, 하지만 server down보다 나음
  - 극심한 traffic: Container restart (30초 downtime) vs 전체 system down (복구 시간 불명)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 프로덕션 배포 시 컨테이너 메모리 및 CPU 제한을 도입하고 JVM 시작/최대 메모리 및 가비지컬렉션 튜닝 옵션을 추가하여 런타임 안정성과 성능 예측성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->