### PR TITLE
fix: 24:00 시간 파싱 오류 수정

### DIFF
--- a/src/main/java/com/gotcha/domain/shop/service/ShopService.java
+++ b/src/main/java/com/gotcha/domain/shop/service/ShopService.java
@@ -356,8 +356,8 @@ public class ShopService {
                 return false;
             }
 
-            LocalTime openTime = LocalTime.parse(times[0].trim());
-            LocalTime closeTime = LocalTime.parse(times[1].trim());
+            LocalTime openTime = parseTimeString(times[0].trim());
+            LocalTime closeTime = parseTimeString(times[1].trim());
 
             // 익일 영업 (overnight) 처리 (예: 22:00-02:00)
             if (closeTime.isBefore(openTime)) {
@@ -371,6 +371,16 @@ public class ShopService {
             log.error("Error checking open status", e);
             return false;
         }
+    }
+
+    /**
+     * 시간 문자열을 LocalTime으로 파싱 ("24:00" → "23:59:59" 변환 포함)
+     */
+    private LocalTime parseTimeString(String timeStr) {
+        if ("24:00".equals(timeStr)) {
+            return LocalTime.of(23, 59, 59);
+        }
+        return LocalTime.parse(timeStr);
     }
 
     /**
@@ -429,8 +439,8 @@ public class ShopService {
                 return "";
             }
 
-            LocalTime openTime = LocalTime.parse(times[0].trim());
-            LocalTime closeTime = LocalTime.parse(times[1].trim());
+            LocalTime openTime = parseTimeString(times[0].trim());
+            LocalTime closeTime = parseTimeString(times[1].trim());
 
             // 익일 영업 (overnight) 처리 (예: 22:00-02:00)
             boolean isCurrentlyOpen;


### PR DESCRIPTION
## Summary
- 영업시간 "24:00" 파싱 시 발생하는 오류 수정
- `parseTimeString()` 헬퍼 메서드 추가하여 "24:00" → "23:59:59" 변환

## 문제
- DB에 "10:00-24:00" 형식의 영업시간 데이터 존재
- `LocalTime.parse("24:00")` 호출 시 `invalid value for hourOfDay (valid values 0 - 23): 24` 오류 발생
- 프로덕션 서버에서 `SERVER_001` 에러 발생

## 해결
```java
private LocalTime parseTimeString(String timeStr) {
    if ("24:00".equals(timeStr)) {
        return LocalTime.of(23, 59, 59);
    }
    return LocalTime.parse(timeStr);
}
```

## Test plan
- [x] 빌드 성공 확인
- [ ] 프로덕션 배포 후 API 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매장 영업 상태 표시 개선으로 자정 시간대 처리 정확성 향상
  * 24시간 형식 시간 표시 오류 수정
  * 야간 영업 시간대의 표시 정확성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->