### PR TITLE
Fix: Optimize memory settings for t3.micro instance (서버 주기적 종료 문제 해결을위한 메모리 최적화)

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -117,11 +117,11 @@ jobs:
               --name gotcha-be-prod \
               -p 8080:8080 \
               --restart unless-stopped \
-              --memory="700m" \
-              --memory-swap="1g" \
+              --memory="750m" \
+              --memory-swap="1536m" \
               --cpus="1.5" \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e JAVA_TOOL_OPTIONS="-Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200" \
+              -e JAVA_TOOL_OPTIONS="-Xms256m -Xmx400m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:MaxMetaspaceSize=128m -XX:ReservedCodeCacheSize=64m" \
               -e SPRING_DATASOURCE_URL="$DB_URL" \
               -e SPRING_DATASOURCE_USERNAME="$DB_USERNAME" \
               -e SPRING_DATASOURCE_PASSWORD="$DB_PASSWORD" \


### PR DESCRIPTION
긴급 수정입니다. (서버가 계속 죽어서)
현재 aws ec2 instance t3.micro 이용중인데
최적화 후에도 계속 죽는다면
t3.small로 일단 변경 후 추가 테스트 예정