### PR TITLE
fix: Increase file upload size limit to 50MB (프로필 사진, 가게 사진 변경시 일부 실패 현상 해결)

### DIFF
--- a/docs/aws-setup-guide.md
+++ b/docs/aws-setup-guide.md
@@ -406,6 +406,9 @@ server {
     listen 443 ssl http2;
     server_name gotcha.com www.gotcha.com;
 
+    # 파일 업로드 크기 제한 (50MB) - 프로필 사진 등 대용량 이미지 지원
+    client_max_body_size 50M;
+
     ssl_certificate /etc/letsencrypt/live/gotcha.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/gotcha.com/privkey.pem;
 

--- a/docs/file-upload-guide.md
+++ b/docs/file-upload-guide.md
@@ -47,7 +47,7 @@ folder: "reviews"  // "shops", "profiles" 중 선택
 
 | 항목 | 제한 |
 |------|------|
-| 파일 크기 | 최대 20MB |
+| 파일 크기 | 최대 50MB |
 | 파일 형식 | jpg, jpeg, png, webp, heic, heif |
 | 폴더명 | reviews, shops, profiles만 허용 |
 
@@ -358,7 +358,7 @@ gotcha-bucket/
 - ❌ 확장자만 검증하면 안 됨 (우회 가능)
 
 ### 3. 파일 크기 제한
-- ✅ 최대 20MB
+- ✅ 최대 50MB
 - 프론트엔드에서도 사전 체크 권장
 
 ### 4. GCS 삭제 시 주의

--- a/docs/log/changelog.md
+++ b/docs/log/changelog.md
@@ -4,6 +4,21 @@
 
 ---
 
+## 2026-01-21
+
+### 수정
+- `src/main/resources/application.yml` - 파일 업로드 크기 제한 증가
+  - 변경: max-file-size 20MB → 50MB (아이폰 고화질 사진 지원)
+  - 변경: max-request-size 20MB → 50MB
+- `src/main/java/com/gotcha/domain/file/service/S3FileUploadService.java` - 파일 크기 검증 로직 수정
+  - 변경: MAX_FILE_SIZE 20MB → 50MB
+- `docs/file-upload-guide.md` - 파일 크기 제한 문서 업데이트
+  - 변경: 최대 파일 크기 20MB → 50MB (2곳)
+- `docs/aws-setup-guide.md` - Nginx 설정에 파일 업로드 크기 제한 추가
+  - 추가: client_max_body_size 50M 설정 (413 Request Entity Too Large 에러 방지)
+
+---
+
 ## 2026-01-18
 
 ### 수정

--- a/src/main/java/com/gotcha/domain/file/service/S3FileUploadService.java
+++ b/src/main/java/com/gotcha/domain/file/service/S3FileUploadService.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class S3FileUploadService implements FileStorageService {
 
-    private static final long MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+    private static final long MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
             "image/jpeg",
             "image/png",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 50MB
+      max-request-size: 50MB
   datasource:
     driver-class-name: org.postgresql.Driver
   jpa:


### PR DESCRIPTION
- Update Spring Boot multipart max-file-size: 20MB → 50MB
- Update S3FileUploadService MAX_FILE_SIZE: 20MB → 50MB
- Add Nginx client_max_body_size 50M configuration