### PR TITLE
feat: 사용자 응답에 userType 필드 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/gotcha/domain/auth/dto/TokenResponse.java
@@ -2,6 +2,7 @@ package com.gotcha.domain.auth.dto;
 
 import com.gotcha.domain.user.entity.SocialType;
 import com.gotcha.domain.user.entity.User;
+import com.gotcha.domain.user.entity.UserType;
 
 public record TokenResponse(
         String accessToken,
@@ -17,6 +18,7 @@ public record TokenResponse(
             String nickname,
             String email,
             SocialType socialType,
+            UserType userType,
             boolean isNewUser
     ) {
         public static UserResponse from(User user, boolean isNewUser) {
@@ -25,6 +27,7 @@ public record TokenResponse(
                     user.getNickname(),
                     user.getEmail(),
                     user.getSocialType(),
+                    user.getUserType(),
                     isNewUser
             );
         }

--- a/src/main/java/com/gotcha/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/gotcha/domain/user/dto/UserResponse.java
@@ -2,6 +2,7 @@ package com.gotcha.domain.user.dto;
 
 import com.gotcha.domain.user.entity.SocialType;
 import com.gotcha.domain.user.entity.User;
+import com.gotcha.domain.user.entity.UserType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "사용자 정보 응답")
@@ -19,7 +20,10 @@ public record UserResponse(
         String profileImageUrl,
 
         @Schema(description = "소셜 로그인 타입", example = "KAKAO")
-        SocialType socialType
+        SocialType socialType,
+
+        @Schema(description = "사용자 타입", example = "NORMAL")
+        UserType userType
 ) {
     public static UserResponse from(User user, String defaultProfileImageUrl) {
         return new UserResponse(
@@ -29,7 +33,8 @@ public record UserResponse(
                 user.getProfileImageUrl() != null && !user.getProfileImageUrl().isBlank()
                         ? user.getProfileImageUrl()
                         : defaultProfileImageUrl,
-                user.getSocialType()
+                user.getSocialType(),
+                user.getUserType()
         );
     }
 }

--- a/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/gotcha/domain/auth/controller/AuthControllerTest.java
@@ -19,6 +19,7 @@ import com.gotcha.domain.auth.dto.TokenResponse;
 import com.gotcha.domain.auth.exception.AuthException;
 import com.gotcha.domain.auth.service.AuthService;
 import com.gotcha.domain.user.entity.SocialType;
+import com.gotcha.domain.user.entity.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -72,7 +73,7 @@ class AuthControllerTest {
             TokenResponse response = new TokenResponse(
                     "new-access-token",
                     "new-refresh-token",
-                    new TokenResponse.UserResponse(1L, "테스트유저", "test@example.com", SocialType.KAKAO, false)
+                    new TokenResponse.UserResponse(1L, "테스트유저", "test@example.com", SocialType.KAKAO, UserType.NORMAL, false)
             );
 
             given(authService.reissueToken(anyString())).willReturn(response);


### PR DESCRIPTION
- UserResponse에 userType 필드 추가 (GET /users/me)
- TokenResponse.UserResponse에 userType 필드 추가 (로그인 응답)
- frontend 에서 ADMIN 여부 확인 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **기능 추가**
  * 사용자 정보 응답에 사용자 유형이 추가되었습니다. 인증 시 발급되는 토큰 응답과 사용자 프로필 조회에서 계정 유형 정보를 함께 제공합니다.

* **테스트**
  * 업데이트된 응답 구조에 맞춰 관련 테스트 코드가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->