### PR TITLE
fix: Apple 인가 요청에 response_mode=form_post 추가

### DIFF
--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.gotcha.domain.auth.oauth2.CustomOidcUserService;
 import com.gotcha.domain.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.gotcha.domain.auth.oauth2.OAuth2AuthenticationFailureHandler;
 import com.gotcha.domain.auth.oauth2.OAuth2AuthenticationSuccessHandler;
+import com.gotcha.domain.auth.oauth2.apple.AppleOAuth2AuthorizationRequestResolver;
 import com.gotcha.domain.auth.oauth2.apple.AppleOAuth2TokenResponseClient;
 import java.util.Arrays;
 import java.util.List;
@@ -38,6 +39,7 @@ public class SecurityConfig {
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final AppleOAuth2AuthorizationRequestResolver appleOAuth2AuthorizationRequestResolver;
     private final AppleOAuth2TokenResponseClient appleOAuth2TokenResponseClient;
 
     @Value("${cors.allowed-origins}")
@@ -97,6 +99,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization ->
                                 authorization.baseUri("/oauth2/authorize")
+                                        .authorizationRequestResolver(appleOAuth2AuthorizationRequestResolver)
                                         .authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository))
                         .redirectionEndpoint(redirection ->
                                 redirection.baseUri("/api/auth/callback/*"))

--- a/src/main/java/com/gotcha/domain/auth/oauth2/apple/AppleOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/com/gotcha/domain/auth/oauth2/apple/AppleOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,54 @@
+package com.gotcha.domain.auth.oauth2.apple;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Apple OAuth2 인가 요청에 response_mode=form_post 파라미터를 추가하는 리졸버.
+ *
+ * Apple은 scope에 name 또는 email이 포함되면 response_mode=form_post를 필수로 요구한다.
+ */
+@Component
+public class AppleOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+
+    public AppleOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, "/oauth2/authorize");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authRequest = defaultResolver.resolve(request);
+        return addResponseModeForApple(authRequest);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authRequest = defaultResolver.resolve(request, clientRegistrationId);
+        return addResponseModeForApple(authRequest);
+    }
+
+    private OAuth2AuthorizationRequest addResponseModeForApple(OAuth2AuthorizationRequest request) {
+        if (request == null) {
+            return null;
+        }
+        if (!request.getAuthorizationUri().contains("appleid.apple.com")) {
+            return request;
+        }
+
+        Map<String, Object> params = new LinkedHashMap<>(request.getAdditionalParameters());
+        params.put("response_mode", "form_post");
+
+        return OAuth2AuthorizationRequest.from(request)
+                .additionalParameters(params)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Apple OAuth2 인가 요청 시 `response_mode=form_post` 파라미터 추가
- Apple은 scope에 `name` 또는 `email`이 포함되면 이 파라미터를 필수로 요구

## 원인
Apple 로그인 시 `invalid_request: response_mode must be form_post when name or email scope is requested` 에러 발생

## 변경 사항
- `AppleOAuth2AuthorizationRequestResolver` 신규 생성 — Apple 요청에만 `response_mode=form_post` 추가
- `SecurityConfig` — 커스텀 리졸버 적용

## Test plan
- [ ] dev 서버 배포 후 Apple 로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Apple 로그인 지원: 사용자가 Apple 계정을 사용하여 서비스에 로그인할 수 있습니다. 기존 인증 방식과 함께 Apple ID를 통한 추가 로그인 옵션이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->