### PR TITLE
fix: Apple OAuth2 콜백 CORS 오류 수정

### DIFF
--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -142,10 +142,10 @@ public class SecurityConfig {
 
         // OAuth2 콜백 - Apple form_post는 Origin: https://appleid.apple.com으로 POST 요청
         CorsConfiguration callbackConfig = new CorsConfiguration();
-        callbackConfig.addAllowedOriginPattern("*");
+        callbackConfig.addAllowedOrigin("https://appleid.apple.com");
         callbackConfig.setAllowedMethods(List.of("GET", "POST"));
         callbackConfig.setAllowedHeaders(List.of("*"));
-        callbackConfig.setAllowCredentials(true);
+        callbackConfig.setAllowCredentials(false);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/auth/callback/*", callbackConfig);


### PR DESCRIPTION
## Summary
- Apple Sign In의 `response_mode=form_post` 방식은 `Origin: https://appleid.apple.com`으로 POST 요청을 보냄
- 기존 CORS 설정은 `cors.allowed-origins` 에 등록된 도메인만 허용하여 Apple 콜백이 차단됨
- `/api/auth/callback/*` 경로에 모든 Origin을 허용하는 별도 CORS 설정 추가

## Changes
- `SecurityConfig.java`: OAuth2 콜백 전용 CORS 설정 추가 (`addAllowedOriginPattern("*")`)

## Test plan
- [ ] Apple 로그인 후 콜백이 정상 처리되는지 확인
- [ ] 기존 카카오/구글/네이버 로그인에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Apple OAuth2 인증 콜백(/api/auth/callback/*)에 대해 별도의 CORS 정책을 도입했습니다. 기존 전역 CORS 설정은 그대로 유지되며, Apple 인증 콜백 경로에만 맞춤형 허용 정책이 적용되어 외부 인증 흐름의 호환성과 안정성이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->