### PR TITLE
fix: OAuth2 쿠키 SameSite=None으로 변경 (Apple form_post 대응)

### DIFF
--- a/src/main/java/com/gotcha/domain/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/gotcha/domain/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -72,11 +72,12 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
         boolean isSecure = isSecureRequest(request);
 
         // 암호화된 OAuth2AuthorizationRequest를 쿠키에 저장
+        // SameSite=None: Apple form_post (cross-site POST)에서 쿠키 전송을 위해 필요
         ResponseCookie authRequestCookie = ResponseCookie.from(OAUTH2_AUTH_REQUEST_COOKIE_NAME, serialized)
                 .path("/")
                 .httpOnly(true)
-                .secure(isSecure)
-                .sameSite("Lax")
+                .secure(true)
+                .sameSite("None")
                 .maxAge(COOKIE_EXPIRE_SECONDS)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, authRequestCookie.toString());
@@ -89,8 +90,8 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
                 ResponseCookie redirectCookie = ResponseCookie.from(REDIRECT_URI_COOKIE_NAME, encodedUri)
                         .path("/")
                         .httpOnly(true)
-                        .secure(isSecure)
-                        .sameSite("Lax")
+                        .secure(true)
+                        .sameSite("None")
                         .maxAge(COOKIE_EXPIRE_SECONDS)
                         .build();
                 response.addHeader(HttpHeaders.SET_COOKIE, redirectCookie.toString());
@@ -139,7 +140,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
                 .path("/")
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Lax")
+                .sameSite("None")
                 .maxAge(0)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
@@ -170,7 +171,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
                 .path("/")
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Lax")
+                .sameSite("None")
                 .maxAge(0)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
## Summary
- Apple `form_post`는 cross-site POST로 `SameSite=Lax` 쿠키가 전송되지 않음
- 콜백 시 인가 요청 쿠키를 찾지 못해 `"authorization request not found"` 에러 발생
- `SameSite=None` + `Secure=true`로 변경하여 cross-site POST에서도 쿠키 전송

## Changes
- `HttpCookieOAuth2AuthorizationRequestRepository`: `sameSite("Lax")` → `sameSite("None")`, `secure(true)` (4군데)

## Why
- `SameSite=Lax`는 CSRF 방어를 위해 cross-site POST에 쿠키를 차단
- Apple의 `response_mode=form_post`는 `appleid.apple.com` → 우리 서버로의 cross-site POST
- 브라우저가 CSRF 공격과 동일한 패턴으로 판단하여 쿠키 차단

## Security
`SameSite=None`이지만 다음 보안 장치로 보완:
- AES-GCM 암호화 (쿠키 내용 읽기/위조 불가)
- `httpOnly` (JavaScript 접근 차단)
- `Secure` (HTTPS에서만 전송)
- 180초 만료 (일회성 임시 쿠키)
- 콜백 처리 후 즉시 삭제

## Test plan
- [ ] dev 환경에서 Apple 로그인 시 "authorization request not found" 에러 해소 확인
- [ ] 카카오/구글/네이버 로그인에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)