### PR TITLE
fix: Add redis container and docker network setting on prod-cicd

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -118,8 +118,13 @@ jobs:
             # Docker 네트워크 생성 (이미 존재하면 무시)
             docker network create gotcha-net || true
 
-            # Redis 컨테이너 실행 (이미 실행 중이면 무시)
-            if ! docker ps | grep -q gotcha-redis; then
+            # Redis 컨테이너 보장 (running/exited/미연결 상태 모두 처리)
+            if docker ps --format '{{.Names}}' | grep -qx 'gotcha-redis'; then
+              docker network connect gotcha-net gotcha-redis 2>/dev/null || true
+            elif docker ps -a --format '{{.Names}}' | grep -qx 'gotcha-redis'; then
+              docker start gotcha-redis
+              docker network connect gotcha-net gotcha-redis 2>/dev/null || true
+            else
               docker run -d \
                 --name gotcha-redis \
                 --network gotcha-net \

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -115,6 +115,18 @@ jobs:
 
             echo "Parameters fetched successfully ✅"
 
+            # Docker 네트워크 생성 (이미 존재하면 무시)
+            docker network create gotcha-net || true
+
+            # Redis 컨테이너 실행 (이미 실행 중이면 무시)
+            if ! docker ps | grep -q gotcha-redis; then
+              docker run -d \
+                --name gotcha-redis \
+                --network gotcha-net \
+                --restart unless-stopped \
+                redis
+            fi
+
             # 기존 컨테이너 중지 및 제거
             docker stop gotcha-be-prod || true
             docker rm gotcha-be-prod || true
@@ -125,6 +137,7 @@ jobs:
             # 새 컨테이너 실행 (t3.small 최적화)
             docker run -d \
               --name gotcha-be-prod \
+              --network gotcha-net \
               -p 8080:8080 \
               --restart unless-stopped \
               --memory="1800m" \
@@ -163,6 +176,7 @@ jobs:
               -e SHOP_DEFAULT_IMAGE_URL="$SHOP_IMG" \
               -e OAUTH2_COOKIE_ENCRYPTION_KEY="$OAUTH_COOKIE_KEY" \
               -e LOKI_URL="$LOKI_URL" \
+              -e REDIS_HOST=gotcha-redis \
               ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
 
             # 컨테이너 상태 확인 (10초 대기 후 확인)


### PR DESCRIPTION
## Summary

- prod CICD 워크플로우에 Docker 네트워크(`gotcha-net`) 자동 생성 추가
- prod CICD 워크플로우에 Redis 컨테이너(`gotcha-redis`) 자동 실행 추가
- 앱 컨테이너에 `--network gotcha-net` 및 `-e REDIS_HOST=gotcha-redis` 환경변수 추가

## Problem

dev → main 머지 후 prod 서버가 기동되지 않는 문제 발생.
원인은 두 가지:

1. `shop_suggestion_reasons` 테이블 누락 → DB에 직접 DDL 실행으로 해결
2. prod CICD에 Redis 설정이 누락되어 있어 로그인 등 Redis 의존 기능이 정상 동작하지 않는 상태

## Changes

- `.github/workflows/cicd-prod.yml` — Redis 컨테이너 실행 및 네트워크 설정 추가

## Note

- Redis/네트워크가 이미 존재하는 경우 스킵하도록 처리 (`|| true`, `if ! docker ps | grep -q`)
- Flyway 미설정으로 인한 수동 마이그레이션 문제는 별도 이슈로 관리 필요. -> 이거 제가 수동으로 sql문 작성해서 했는데, 버전 바뀔때마다 수동으로 관리하기가 힘들어서 도입좀 해야할 것 같아요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD 파이프라인이 배포 시 Redis 인프라 구성과 애플리케이션 환경변수 설정을 자동으로 처리하도록 개선되어 배포 안정성 및 환경 일관성이 향상되었습니다. 네트워크 연결과 재시작 동작을 관리해 장애 복구와 서비스 지속성이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->