### PR TITLE
feat : GET /api/users/me 응답에 찜/신고/리뷰 수 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/gotcha/domain/favorite/repository/FavoriteRepository.java
@@ -20,6 +20,8 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     Long countByShopId(Long shopId);
 
+    Long countByUserId(Long userId);
+
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Favorite f WHERE f.user.id = :userId AND f.shop.id = :shopId")
     void deleteByUserIdAndShopId(@Param("userId") Long userId, @Param("shopId") Long shopId);

--- a/src/main/java/com/gotcha/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/gotcha/domain/report/repository/ReportRepository.java
@@ -13,6 +13,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
+    Long countByReporterId(Long reporterId);
+
     boolean existsByReporterIdAndTargetTypeAndTargetIdAndStatusNot(
             Long reporterId, ReportTargetType targetType, Long targetId, ReportStatus status);
 

--- a/src/main/java/com/gotcha/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/gotcha/domain/review/repository/ReviewRepository.java
@@ -45,6 +45,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Long countByShopId(Long shopId);
 
+    Long countByUserId(Long userId);
+
     @Query("SELECT COUNT(r) FROM Review r WHERE r.shop.id = :shopId " +
             "AND r.user.id NOT IN :blockedUserIds")
     Long countByShopIdExcludingBlockedUsers(

--- a/src/main/java/com/gotcha/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.gotcha._global.common.PageResponse;
 import com.gotcha.domain.auth.util.CookieUtils;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.favorite.service.FavoriteService;
+import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
 import com.gotcha.domain.user.dto.UpdateProfileImageRequest;
@@ -38,7 +39,7 @@ public class UserController implements UserControllerApi {
 
     @Override
     @GetMapping("/me")
-    public ApiResponse<UserResponse> getMyInfo() {
+    public ApiResponse<MyInfoResponse> getMyInfo() {
         return ApiResponse.success(userService.getMyInfo());
     }
 

--- a/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
@@ -3,6 +3,7 @@ package com.gotcha.domain.user.controller;
 import com.gotcha._global.common.ApiResponse;
 import com.gotcha._global.common.PageResponse;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
+import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
 import com.gotcha.domain.user.dto.UpdateProfileImageRequest;
@@ -45,7 +46,11 @@ public interface UserControllerApi {
                                         "nickname": "빨간캡슐#21",
                                         "email": "user@example.com",
                                         "profileImageUrl": "https://storage.googleapis.com/gotcha-dev-files/profile-default-join.png",
-                                        "socialType": "KAKAO"
+                                        "socialType": "KAKAO",
+                                        "userType": "NORMAL",
+                                        "favoriteCount": 12,
+                                        "reportCount": 3,
+                                        "reviewCount": 7
                                       }
                                     }
                                     """)
@@ -97,7 +102,7 @@ public interface UserControllerApi {
                     )
             )
     })
-    ApiResponse<UserResponse> getMyInfo();
+    ApiResponse<MyInfoResponse> getMyInfo();
 
     @Operation(
             summary = "내 찜 목록 조회",

--- a/src/main/java/com/gotcha/domain/user/dto/MyInfoResponse.java
+++ b/src/main/java/com/gotcha/domain/user/dto/MyInfoResponse.java
@@ -1,0 +1,53 @@
+package com.gotcha.domain.user.dto;
+
+import com.gotcha.domain.user.entity.SocialType;
+import com.gotcha.domain.user.entity.User;
+import com.gotcha.domain.user.entity.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 정보 응답")
+public record MyInfoResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        Long id,
+
+        @Schema(description = "닉네임", example = "빨간캡슐#21")
+        String nickname,
+
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(description = "소셜 로그인 타입", example = "KAKAO")
+        SocialType socialType,
+
+        @Schema(description = "사용자 타입", example = "NORMAL")
+        UserType userType,
+
+        @Schema(description = "찜한 가게 수", example = "12")
+        long favoriteCount,
+
+        @Schema(description = "신고 수", example = "3")
+        long reportCount,
+
+        @Schema(description = "리뷰 수", example = "7")
+        long reviewCount
+) {
+    public static MyInfoResponse from(User user, String defaultProfileImageUrl,
+            long favoriteCount, long reportCount, long reviewCount) {
+        return new MyInfoResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getProfileImageUrl() != null && !user.getProfileImageUrl().isBlank()
+                        ? user.getProfileImageUrl()
+                        : defaultProfileImageUrl,
+                user.getSocialType(),
+                user.getUserType(),
+                favoriteCount,
+                reportCount,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/com/gotcha/domain/user/service/UserService.java
+++ b/src/main/java/com/gotcha/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.gotcha.domain.chat.repository.ChatRepository;
 import com.gotcha.domain.chat.repository.ChatRoomRepository;
 import com.gotcha.domain.comment.repository.CommentRepository;
 import com.gotcha.domain.favorite.repository.FavoriteRepository;
+import com.gotcha.domain.report.repository.ReportRepository;
 import com.gotcha.domain.file.service.FileStorageService;
 import com.gotcha.domain.inquiry.repository.InquiryRepository;
 import com.gotcha.domain.post.entity.Post;
@@ -26,6 +27,7 @@ import com.gotcha.domain.shop.entity.Shop;
 import com.gotcha.domain.shop.repository.ShopSuggestionRepository;
 import com.gotcha.domain.shop.repository.ShopRepository;
 import com.gotcha.domain.shop.service.ShopService;
+import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.UserNicknameResponse;
 import com.gotcha.domain.user.dto.UserResponse;
@@ -58,6 +60,7 @@ public class UserService {
     private final WithdrawalSurveyRepository withdrawalSurveyRepository;
     private final RedisRefreshTokenStore redisRefreshTokenStore;
     private final FavoriteRepository favoriteRepository;
+    private final ReportRepository reportRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
     private final ReviewLikeRepository reviewLikeRepository;
@@ -82,9 +85,12 @@ public class UserService {
     /**
      * 내 정보 조회
      */
-    public UserResponse getMyInfo() {
+    public MyInfoResponse getMyInfo() {
         User user = securityUtil.getCurrentUser();
-        return UserResponse.from(user, defaultProfileImageUrl);
+        long favoriteCount = favoriteRepository.countByUserId(user.getId());
+        long reportCount = reportRepository.countByReporterId(user.getId());
+        long reviewCount = reviewRepository.countByUserId(user.getId());
+        return MyInfoResponse.from(user, defaultProfileImageUrl, favoriteCount, reportCount, reviewCount);
     }
 
     /**


### PR DESCRIPTION
response에 
 {                                                                                                                                                                           
    "favoriteCount": 12,
    "reportCount": 3,                                                                                                                                                     
    "reviewCount": 7 
  }   
추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사용자 정보 조회 엔드포인트 확장: 사용자의 기본 정보(닉네임, 이메일, 프로필 이미지, 계정 유형)에 더하여 사용자의 활동 통계(관심 상품 개수, 신고 개수, 리뷰 개수)를 함께 반환하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->