### PR TITLE
fix: cicd deps

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -30,7 +30,7 @@ jobs:
           # 기존 app 컨테이너 중지 및 제거
           docker compose stop app || true
           docker compose rm -f app || true
-          docker compose up -d --force-recreate --no-deps app
+          docker compose up -d --force-recreate app
 
           # 컨테이너 상태 확인 (최대 60초, 2초 간격 폴링)
           for i in $(seq 1 30); do

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -27,24 +27,34 @@ jobs:
         run: |
           cd ~/apps/gotcha/dev
 
+          # DB, Redis 먼저 보장
+          docker compose up -d db redis
+
           # 기존 app 컨테이너 중지 및 제거
           docker compose stop app || true
           docker compose rm -f app || true
           docker compose up -d --force-recreate app
 
           # 컨테이너 상태 확인 (최대 60초, 2초 간격 폴링)
+          deploy_failed=false
           for i in $(seq 1 30); do
             status=$(docker inspect -f '{{.State.Status}}' gotcha-app-dev 2>/dev/null || echo "missing")
             health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' gotcha-app-dev 2>/dev/null || echo "missing")
             if [ "$status" = "running" ] && { [ "$health" = "healthy" ] || [ "$health" = "none" ]; }; then
               echo "Container is up (status=$status, health=$health)"
-              exit 0
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "Container failed to become healthy (status=$status, health=$health)"
+              docker logs --tail=200 gotcha-app-dev || true
+              deploy_failed=true
             fi
             sleep 2
           done
-          echo "Container failed to become healthy (status=$status, health=$health)"
-          docker logs --tail=200 gotcha-app-dev || true
-          exit 1
 
           # 이전 이미지 정리
           docker image prune -f
+
+          if [ "$deploy_failed" = "true" ]; then
+            exit 1
+          fi

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -30,7 +30,7 @@ jobs:
           # 기존 app 컨테이너 중지 및 제거
           docker compose stop app || true
           docker compose rm -f app || true
-          docker compose up -d --force-recreate --no-deps app
+          docker compose up -d --force-recreate app
 
           # 컨테이너 상태 확인 (최대 60초, 2초 간격 폴링)
           for i in $(seq 1 30); do

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -27,24 +27,34 @@ jobs:
         run: |
           cd ~/apps/gotcha/prod
 
+          # DB, Redis 먼저 보장
+          docker compose up -d db redis
+
           # 기존 app 컨테이너 중지 및 제거
           docker compose stop app || true
           docker compose rm -f app || true
           docker compose up -d --force-recreate app
 
           # 컨테이너 상태 확인 (최대 60초, 2초 간격 폴링)
+          deploy_failed=false
           for i in $(seq 1 30); do
             status=$(docker inspect -f '{{.State.Status}}' gotcha-app-prod 2>/dev/null || echo "missing")
             health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' gotcha-app-prod 2>/dev/null || echo "missing")
             if [ "$status" = "running" ] && { [ "$health" = "healthy" ] || [ "$health" = "none" ]; }; then
               echo "Container is up (status=$status, health=$health)"
-              exit 0
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "Container failed to become healthy (status=$status, health=$health)"
+              docker logs --tail=200 gotcha-app-prod || true
+              deploy_failed=true
             fi
             sleep 2
           done
-          echo "Container failed to become healthy (status=$status, health=$health)"
-          docker logs --tail=200 gotcha-app-prod || true
-          exit 1
 
           # 이전 이미지 정리
           docker image prune -f
+
+          if [ "$deploy_failed" = "true" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

### 변경 사항
- **DB/Redis 선행 기동 보장**: 배포 시 `docker compose up -d db redis`를 먼저 실행하여, 서버 재부팅 등으로 DB/Redis가 꺼진 상태에서도 앱이 안전하게 기동되도록 수정
- **이미지 정리 누락 수정**: 헬스체크 성공 시 `exit 0`으로 스크립트가 종료되어 `docker image prune -f`가 실행되지 않던 문제 수정 → `break`로 변경하여 이미지 정리 후 종료되도록 개선
- prod, dev 워크플로우 동일하게 적용

### 배경
- 이전 배포에서 Redis 컨테이너가 미기동 상태로 앱이 뜨면서 `health: DOWN` 발생했던 이슈 해결
- `--force-recreate app` 사용 시 `depends_on`이 있어도 이미 중지된 의존 컨테이너를 자동으로 띄워주지 않을 수 있음

## Test plan
- [ ] 서버 재부팅 후 dev merge 시 DB/Redis/App 순서대로 정상 기동 확인
- [ ] 배포 성공 시 `docker image prune -f` 실행 확인
- [ ] 배포 실패 시에도 이미지 정리 후 exit 1 반환 확인