### PR TITLE
fix: logback <root> 내 <if> 중첩 제거로 로그 출력 복구

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -74,11 +74,6 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <if condition='!property("LOKI_URL").equals("")'>
-                <then>
-                    <appender-ref ref="ASYNC_LOKI"/>
-                </then>
-            </if>
         </root>
         <logger name="com.gotcha" level="DEBUG"/>
         <logger name="org.springframework.web" level="INFO"/>
@@ -89,15 +84,21 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <if condition='!property("LOKI_URL").equals("")'>
-                <then>
-                    <appender-ref ref="ASYNC_LOKI"/>
-                </then>
-            </if>
         </root>
         <logger name="com.gotcha" level="INFO"/>
         <logger name="org.springframework.web" level="WARN"/>
         <logger name="org.hibernate" level="WARN"/>
+    </springProfile>
+
+    <!-- Loki appender: conditionally added when LOKI_URL is set -->
+    <springProfile name="dev,prod">
+        <if condition='!property("LOKI_URL").equals("")'>
+            <then>
+                <root level="INFO">
+                    <appender-ref ref="ASYNC_LOKI"/>
+                </root>
+            </then>
+        </if>
     </springProfile>
 
 </configuration>


### PR DESCRIPTION
## Summary

- `logback-spring.xml`에서 `<root>` 내부의 `<if>` 중첩을 제거하여 로그 출력 복구
- 최신 logback(1.5.x)에서 `<root>` 안에 `<if>`를 중첩하면 root logger에 appender가 등록되지 않아 모든 로그 출력이 사라지는 버그 수정
- Loki 조건부 추가를 별도 `<springProfile>` 블록으로 분리

### 변경 전
```xml
<springProfile name="dev">
    <root level="INFO">
        <appender-ref ref="CONSOLE"/>
        <appender-ref ref="FILE"/>
        <if condition='...'>           <!-- root 안에 if 중첩 → logback이 거부 -->
            <then>
                <appender-ref ref="ASYNC_LOKI"/>
            </then>
        </if>
    </root>
</springProfile>
```

### 변경 후
- `<root>`에는 CONSOLE, FILE만 직접 등록
- Loki appender는 별도 `<springProfile name="dev,prod">` 블록에서 조건부 추가


### 로그 관리 방식

| 항목 | 설명 |
|------|------|
| 콘솔 | `docker logs -f <container>`로 실시간 확인 |
| 파일 경로 | 홈서버 `~/apps/gotcha/{dev,prod}/logs/app/gotcha-server.log` |
| 롤링 | 일별 + 100MB 단위로 분리, .gz 자동 압축 |
| 보관 기간 | 30일 |
| 최대 용량 | 3GB |
| Loki | `LOKI_URL` 환경변수 설정 시에만 활성화 (현재 비활성) |

## Test plan

- [ ] dev 배포 후 `docker logs -f gotcha-app-dev`에서 요청 로그 출력 확인
- [ ] `~/apps/gotcha/dev/logs/app/gotcha-server.log` 파일에 로그 기록 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로깅 구성을 개선했습니다. Loki 로깅이 이제 `LOKI_URL` 환경 변수 설정 여부에 따라 조건부로 활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->