### PR TITLE
feat: 커뮤니티 게시글 기능 확장 (매장 연결, 공개/비공개, 수정/인기글, 신고)

### DIFF
--- a/src/main/java/com/gotcha/domain/post/controller/PostController.java
+++ b/src/main/java/com/gotcha/domain/post/controller/PostController.java
@@ -10,6 +10,10 @@ import com.gotcha.domain.post.dto.PostCursorResponse;
 import com.gotcha.domain.post.dto.PostDetailResponse;
 import com.gotcha.domain.post.dto.PostLikeResponse;
 import com.gotcha.domain.post.dto.PostResponse;
+import com.gotcha.domain.post.dto.PostShopInfo;
+import com.gotcha.domain.post.dto.PostSortType;
+import com.gotcha.domain.post.dto.UpdatePostRequest;
+import java.util.List;
 import com.gotcha.domain.post.service.PostCommentLikeService;
 import com.gotcha.domain.post.service.PostCommentService;
 import com.gotcha.domain.post.service.PostLikeService;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,12 +44,23 @@ public class PostController implements PostControllerApi {
     private final SecurityUtil securityUtil;
 
     @Override
+    @GetMapping("/shops/search")
+    public ApiResponse<List<PostShopInfo>> searchShops(@RequestParam String keyword) {
+        return ApiResponse.success(postService.searchShopsForPost(keyword));
+    }
+
+    @Override
     @GetMapping
     public ApiResponse<PostCursorResponse> getPosts(
             @RequestParam(required = false) Long typeId,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "LATEST") PostSortType sort
     ) {
+        if (sort == PostSortType.POPULAR) {
+            return ApiResponse.success(postService.getPopularPosts(typeId, page, size));
+        }
         return ApiResponse.success(postService.getPostsByCursor(typeId, cursor, size));
     }
 
@@ -73,6 +89,15 @@ public class PostController implements PostControllerApi {
     @DeleteMapping("/{postId}/like")
     public ApiResponse<PostLikeResponse> removeLike(@PathVariable Long postId) {
         return ApiResponse.success(postLikeService.removeLike(postId));
+    }
+
+    @Override
+    @PutMapping("/{postId}")
+    public ApiResponse<PostResponse> updatePost(
+            @PathVariable Long postId,
+            @Valid @RequestBody UpdatePostRequest request
+    ) {
+        return ApiResponse.success(postService.updatePost(postId, request));
     }
 
     @Override

--- a/src/main/java/com/gotcha/domain/post/controller/PostControllerApi.java
+++ b/src/main/java/com/gotcha/domain/post/controller/PostControllerApi.java
@@ -11,6 +11,10 @@ import com.gotcha.domain.post.dto.PostCursorResponse;
 import com.gotcha.domain.post.dto.PostDetailResponse;
 import com.gotcha.domain.post.dto.PostLikeResponse;
 import com.gotcha.domain.post.dto.PostResponse;
+import com.gotcha.domain.post.dto.PostShopInfo;
+import com.gotcha.domain.post.dto.PostSortType;
+import com.gotcha.domain.post.dto.UpdatePostRequest;
+import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,18 +30,31 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Post", description = "커뮤니티 게시글 API")
 public interface PostControllerApi {
 
-    @Operation(summary = "게시글 목록 조회 (커서 기반 무한 스크롤)",
-            description = "커뮤니티 게시글 목록을 커서 기반으로 조회합니다. " +
-                    "typeId 없으면 전체, 있으면 해당 카테고리만 조회합니다. " +
-                    "cursor 없으면 첫 페이지, 있으면 해당 ID 이후 데이터를 반환합니다. " +
-                    "응답의 nextCursor를 다음 요청의 cursor로 사용하세요.")
+    @Operation(summary = "게시글 작성용 매장 검색",
+            description = "게시글 작성 시 연결할 매장을 검색합니다. 매장 이름으로 부분 검색하며 최대 50개를 반환합니다. " +
+                    "검색어가 2자 미만이면 빈 배열을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공")
+    })
+    ApiResponse<List<PostShopInfo>> searchShops(
+            @Parameter(description = "검색어 (매장 이름, 2자 이상)") @RequestParam String keyword
+    );
+
+    @Operation(summary = "게시글 목록 조회",
+            description = "커뮤니티 게시글 목록을 조회합니다. sort 값에 따라 동작이 달라집니다. " +
+                    "LATEST(기본): 최신순 커서 기반 무한 스크롤 — `cursor`와 `size` 사용. " +
+                    "POPULAR: 최근 7일간 좋아요 많은 순 페이지 기반 — `page`와 `size` 사용. " +
+                    "typeId 지정 시 해당 카테고리만 조회됩니다. " +
+                    "응답의 hasNext로 다음 데이터 존재 여부를 판단합니다 (LATEST는 nextCursor도 함께 사용).")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
     ApiResponse<PostCursorResponse> getPosts(
             @Parameter(description = "카테고리 ID (없으면 전체 조회)") @RequestParam(required = false) Long typeId,
-            @Parameter(description = "마지막으로 받은 게시글 ID (첫 요청 시 생략)") @RequestParam(required = false) Long cursor,
-            @Parameter(description = "조회 개수 (기본 20)") @RequestParam(defaultValue = "20") int size
+            @Parameter(description = "마지막으로 받은 게시글 ID (LATEST 정렬에서만 사용)") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "페이지 번호 (POPULAR 정렬에서만 사용, 기본 0)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "조회 개수 (기본 20)") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "정렬 방식: LATEST(기본, 최신순) 또는 POPULAR(인기순, 최근 7일)") @RequestParam(defaultValue = "LATEST") PostSortType sort
     );
 
     @Operation(summary = "게시글 상세 조회",
@@ -63,6 +80,30 @@ public interface PostControllerApi {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<PostResponse> createPost(@Valid @RequestBody CreatePostRequest request);
+
+    @Operation(summary = "게시글 수정",
+            description = "게시글을 수정합니다. 작성자 본인만 가능합니다. 이미지는 전체 교체됩니다 (기존 이미지는 S3에서 삭제). " +
+                    "공개 여부(isPublic)는 작성 시점에만 설정 가능하며 수정으로는 변경할 수 없습니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+                    description = "잘못된 요청 (PT002: 카테고리 없음, PT003: 이미지 개수 초과)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    description = "로그인 필요 (A001)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403",
+                    description = "본인의 게시글만 수정 가능 (PT004)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+                    description = "게시글을 찾을 수 없음 (PT001)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<PostResponse> updatePost(
+            @PathVariable Long postId,
+            @Valid @RequestBody UpdatePostRequest request
+    );
 
     @Operation(summary = "게시글 삭제",
             description = "게시글을 삭제합니다. 작성자 본인 또는 ADMIN만 가능합니다. 이미지(S3), 댓글, 좋아요가 함께 삭제됩니다.",

--- a/src/main/java/com/gotcha/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.gotcha.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gotcha.domain.post.entity.Post;
 import com.gotcha.domain.post.entity.PostImage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,14 +22,18 @@ public record PostDetailResponse(
         @Schema(description = "작성자 닉네임", example = "빨간캡슐#21")
         String authorNickname,
 
-        @Schema(description = "제목", example = "오늘 갓챠샵 다녀왔어요!")
-        String title,
-
         @Schema(description = "본문 내용", example = "오늘 드디어 원하던 캐릭터를 뽑았어요!")
         String content,
 
         @Schema(description = "이미지 URL 목록")
         List<String> imageUrls,
+
+        @Schema(description = "연결된 매장 정보 (매장 미지정 시 응답에서 제외)")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        PostShopInfo shopInfo,
+
+        @Schema(description = "공개 여부", example = "true")
+        boolean isPublic,
 
         @Schema(description = "좋아요 수", example = "10")
         long likeCount,
@@ -58,9 +63,10 @@ public record PostDetailResponse(
                 post.getType().getId(),
                 post.getType().getTypeName(),
                 post.getUser().getNickname(),
-                post.getTitle(),
                 post.getContent(),
                 images.stream().map(PostImage::getImageUrl).toList(),
+                post.getShop() != null ? PostShopInfo.from(post.getShop()) : null,
+                post.isPublic(),
                 likeCount,
                 isLiked,
                 isOwner,

--- a/src/main/java/com/gotcha/domain/post/dto/PostListItemResponse.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostListItemResponse.java
@@ -1,5 +1,6 @@
 package com.gotcha.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gotcha.domain.post.entity.Post;
 import com.gotcha.domain.post.entity.PostImage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,6 +20,9 @@ public record PostListItemResponse(
         @Schema(description = "카테고리명", example = "갓챠일상")
         String typeName,
 
+        @Schema(description = "작성자 ID (차단 등에 사용)", example = "5")
+        Long authorId,
+
         @Schema(description = "작성자 닉네임", example = "빨간캡슐#21")
         String authorNickname,
 
@@ -30,6 +34,16 @@ public record PostListItemResponse(
 
         @Schema(description = "이미지 URL 목록 (최대 5개)")
         List<String> imageUrls,
+
+        @Schema(description = "연결된 매장 정보 (매장 미지정 시 응답에서 제외)")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        PostShopInfo shopInfo,
+
+        @Schema(description = "공개 여부", example = "true")
+        boolean isPublic,
+
+        @Schema(description = "본인 작성 여부 (비로그인 시 false)", example = "false")
+        boolean isOwner,
 
         @Schema(description = "좋아요 수", example = "12")
         long likeCount,
@@ -43,15 +57,22 @@ public record PostListItemResponse(
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
 ) {
-    public static PostListItemResponse of(Post post, List<PostImage> images, long likeCount, long commentCount) {
+    public static PostListItemResponse of(Post post, List<PostImage> images, long likeCount,
+                                          long commentCount, Long currentUserId) {
+        Long authorId = post.getUser().getId();
+        boolean isOwner = currentUserId != null && authorId.equals(currentUserId);
         return new PostListItemResponse(
                 post.getId(),
                 post.getType().getId(),
                 post.getType().getTypeName(),
+                authorId,
                 post.getUser().getNickname(),
                 post.getUser().getProfileImageUrl(),
                 post.getContent(),
                 images.stream().map(PostImage::getImageUrl).toList(),
+                post.getShop() != null ? PostShopInfo.from(post.getShop()) : null,
+                post.isPublic(),
+                isOwner,
                 likeCount,
                 commentCount,
                 formatTimeAgo(post.getCreatedAt()),

--- a/src/main/java/com/gotcha/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostResponse.java
@@ -21,14 +21,17 @@ public record PostResponse(
         @Schema(description = "작성자 닉네임", example = "빨간캡슐#21")
         String authorNickname,
 
-        @Schema(description = "제목", example = "오늘 갓챠샵 다녀왔어요!")
-        String title,
-
         @Schema(description = "본문 내용", example = "오늘 드디어 원하던 캐릭터를 뽑았어요!")
         String content,
 
         @Schema(description = "이미지 URL 목록")
         List<String> imageUrls,
+
+        @Schema(description = "연결된 매장 정보 (선택)")
+        PostShopInfo shopInfo,
+
+        @Schema(description = "공개 여부", example = "true")
+        boolean isPublic,
 
         @Schema(description = "작성 시간")
         LocalDateTime createdAt
@@ -39,9 +42,10 @@ public record PostResponse(
                 post.getType().getId(),
                 post.getType().getTypeName(),
                 post.getUser().getNickname(),
-                post.getTitle(),
                 post.getContent(),
                 images.stream().map(PostImage::getImageUrl).toList(),
+                post.getShop() != null ? PostShopInfo.from(post.getShop()) : null,
+                post.isPublic(),
                 post.getCreatedAt()
         );
     }

--- a/src/main/java/com/gotcha/domain/post/dto/PostShopInfo.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostShopInfo.java
@@ -1,0 +1,21 @@
+package com.gotcha.domain.post.dto;
+
+import com.gotcha.domain.shop.entity.Shop;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글에 연결된 매장 정보")
+public record PostShopInfo(
+
+        @Schema(description = "매장 ID", example = "1")
+        Long shopId,
+
+        @Schema(description = "매장 이름", example = "강남 가챠샵")
+        String shopName,
+
+        @Schema(description = "매장 주소", example = "서울특별시 강남구 강남대로 364")
+        String shopAddress
+) {
+    public static PostShopInfo from(Shop shop) {
+        return new PostShopInfo(shop.getId(), shop.getName(), shop.getAddressName());
+    }
+}

--- a/src/main/java/com/gotcha/domain/post/dto/PostSortType.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostSortType.java
@@ -1,0 +1,13 @@
+package com.gotcha.domain.post.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 정렬 방식")
+public enum PostSortType {
+
+    /** 최신순 (기본, 커서 기반) */
+    LATEST,
+
+    /** 인기순 (최근 7일 좋아요 많은 순, 페이지 기반) */
+    POPULAR
+}

--- a/src/main/java/com/gotcha/domain/post/dto/UpdatePostRequest.java
+++ b/src/main/java/com/gotcha/domain/post/dto/UpdatePostRequest.java
@@ -6,28 +6,24 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-@Schema(description = "게시글 작성 요청")
-public record CreatePostRequest(
+@Schema(description = "게시글 수정 요청")
+public record UpdatePostRequest(
 
         @Schema(description = "카테고리 ID", example = "1")
         @NotNull(message = "카테고리는 필수입니다")
         Long typeId,
 
-        @Schema(description = "연결할 매장 ID (선택)", example = "1")
+        @Schema(description = "연결할 매장 ID (선택, null 보내면 매장 연결 해제)", example = "1")
         Long shopId,
 
-        @Schema(description = "본문 내용", example = "오늘 드디어 원하던 캐릭터를 뽑았어요!")
+        @Schema(description = "본문 내용", example = "수정된 본문 내용입니다")
         @NotBlank(message = "본문은 필수입니다")
         @Size(max = 10000, message = "본문은 10000자 이하여야 합니다")
         String content,
 
-        @Schema(description = "이미지 URL 목록 (선택, 최대 5개). null 또는 빈 리스트 = 이미지 없음",
+        @Schema(description = "이미지 URL 목록 (최대 5개). null 또는 빈 리스트 = 이미지 없음. 기존 이미지는 모두 대체됨",
                 example = "[\"https://example.com/image1.jpg\"]")
         @Size(max = 5, message = "이미지는 최대 5개까지 첨부 가능합니다")
-        List<@NotBlank(message = "이미지 URL은 빈 값일 수 없습니다") String> imageUrls,
-
-        @Schema(description = "공개 여부 (선택, 기본 true). false면 작성자 본인과 관리자만 조회 가능",
-                example = "true")
-        Boolean isPublic
+        List<@NotBlank(message = "이미지 URL은 빈 값일 수 없습니다") String> imageUrls
 ) {
 }

--- a/src/main/java/com/gotcha/domain/post/entity/Post.java
+++ b/src/main/java/com/gotcha/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.gotcha.domain.post.entity;
 
 import com.gotcha._global.entity.BaseTimeEntity;
+import com.gotcha.domain.shop.entity.Shop;
 import com.gotcha.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Table(name = "posts")
@@ -34,22 +36,29 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "type_id", nullable = false)
     private PostType type;
 
-    @Column(nullable = false, length = 200)
-    private String title;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "is_public", nullable = false)
+    @ColumnDefault("true")
+    private boolean isPublic;
+
     @Builder
-    public Post(User user, PostType type, String title, String content) {
+    public Post(User user, PostType type, Shop shop, String content, Boolean isPublic) {
         this.user = user;
         this.type = type;
-        this.title = title;
+        this.shop = shop;
         this.content = content;
+        this.isPublic = isPublic == null || isPublic;
     }
 
-    public void update(String title, String content) {
-        this.title = title;
+    public void update(PostType type, Shop shop, String content) {
+        this.type = type;
+        this.shop = shop;
         this.content = content;
     }
 }

--- a/src/main/java/com/gotcha/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/com/gotcha/domain/post/exception/PostErrorCode.java
@@ -24,7 +24,8 @@ public enum PostErrorCode implements ErrorCode {
     COMMENT_UNAUTHORIZED(FORBIDDEN, "PT008", "본인의 댓글만 수정/삭제할 수 있습니다"),
     REPLY_DEPTH_EXCEEDED(BAD_REQUEST, "PT009", "대댓글에는 댓글을 달 수 없습니다"),
     COMMENT_ALREADY_LIKED(CONFLICT, "PT010", "이미 좋아요한 댓글입니다"),
-    COMMENT_LIKE_NOT_FOUND(NOT_FOUND, "PT011", "댓글 좋아요를 찾을 수 없습니다");
+    COMMENT_LIKE_NOT_FOUND(NOT_FOUND, "PT011", "댓글 좋아요를 찾을 수 없습니다"),
+    POST_PRIVATE(FORBIDDEN, "PT012", "비공개 게시글은 작성자와 관리자만 조회할 수 있습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/gotcha/domain/post/exception/PostException.java
+++ b/src/main/java/com/gotcha/domain/post/exception/PostException.java
@@ -52,4 +52,8 @@ public class PostException extends BusinessException {
     public static PostException commentLikeNotFound() {
         return new PostException(PostErrorCode.COMMENT_LIKE_NOT_FOUND);
     }
+
+    public static PostException privatePost() {
+        return new PostException(PostErrorCode.POST_PRIVATE);
+    }
 }

--- a/src/main/java/com/gotcha/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/gotcha/domain/post/repository/PostRepository.java
@@ -13,50 +13,65 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 페이지 기반 (정렬: createdAt DESC) — 비공개 글은 본인만 노출
-    @EntityGraph(attributePaths = {"user", "type"})
+    // 페이지 기반 (정렬: createdAt DESC) — 비공개 글은 작성자 본인 또는 ADMIN만 노출
+    @EntityGraph(attributePaths = {"user", "type", "shop"})
     @Query("SELECT p FROM Post p "
-            + "WHERE (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "WHERE (p.isPublic = true "
+            + "       OR :isAdmin = true "
+            + "       OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
             + "ORDER BY p.createdAt DESC")
-    Page<Post> findVisibleAll(@Param("currentUserId") Long currentUserId, Pageable pageable);
+    Page<Post> findVisibleAll(@Param("currentUserId") Long currentUserId,
+                              @Param("isAdmin") boolean isAdmin,
+                              Pageable pageable);
 
-    @EntityGraph(attributePaths = {"user", "type"})
+    @EntityGraph(attributePaths = {"user", "type", "shop"})
     @Query("SELECT p FROM Post p "
             + "WHERE p.type.id = :typeId "
-            + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "AND (p.isPublic = true "
+            + "     OR :isAdmin = true "
+            + "     OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
             + "ORDER BY p.createdAt DESC")
     Page<Post> findVisibleByTypeId(@Param("typeId") Long typeId,
                                    @Param("currentUserId") Long currentUserId,
+                                   @Param("isAdmin") boolean isAdmin,
                                    Pageable pageable);
 
-    // Cursor 기반 (id DESC = 최신순) — 비공개 글은 본인만 노출
-    @EntityGraph(attributePaths = {"user", "type"})
+    // Cursor 기반 (id DESC = 최신순) — 비공개 글은 작성자 본인 또는 ADMIN만 노출
+    @EntityGraph(attributePaths = {"user", "type", "shop"})
     @Query("SELECT p FROM Post p "
             + "WHERE (:cursorId IS NULL OR p.id < :cursorId) "
             + "AND (:typeId IS NULL OR p.type.id = :typeId) "
-            + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "AND (p.isPublic = true "
+            + "     OR :isAdmin = true "
+            + "     OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
             + "ORDER BY p.id DESC")
     List<Post> findVisibleByCursor(@Param("typeId") Long typeId,
                                    @Param("cursorId") Long cursorId,
                                    @Param("currentUserId") Long currentUserId,
+                                   @Param("isAdmin") boolean isAdmin,
                                    Pageable pageable);
 
-    // 인기글 (since 이후 작성된 게시글 중 좋아요 수 많은 순)
-    @EntityGraph(attributePaths = {"user", "type"})
+    // 인기글 (since 이후 작성된 게시글 중 좋아요 수 많은 순) — 비공개 글은 작성자 본인 또는 ADMIN만 노출
+    @EntityGraph(attributePaths = {"user", "type", "shop"})
     @Query(
             value = "SELECT p FROM Post p LEFT JOIN PostLike pl ON pl.post = p "
                     + "WHERE p.createdAt >= :since "
-                    + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+                    + "AND (p.isPublic = true "
+                    + "     OR :isAdmin = true "
+                    + "     OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
                     + "AND (:typeId IS NULL OR p.type.id = :typeId) "
                     + "GROUP BY p "
                     + "ORDER BY COUNT(pl) DESC, p.id DESC",
             countQuery = "SELECT COUNT(p) FROM Post p "
                     + "WHERE p.createdAt >= :since "
-                    + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+                    + "AND (p.isPublic = true "
+                    + "     OR :isAdmin = true "
+                    + "     OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
                     + "AND (:typeId IS NULL OR p.type.id = :typeId)"
     )
     Page<Post> findPopularPosts(@Param("typeId") Long typeId,
                                 @Param("currentUserId") Long currentUserId,
+                                @Param("isAdmin") boolean isAdmin,
                                 @Param("since") LocalDateTime since,
                                 Pageable pageable);
 

--- a/src/main/java/com/gotcha/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/gotcha/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.gotcha.domain.post.repository;
 
 import com.gotcha.domain.post.entity.Post;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,24 +13,52 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    // 페이지 기반 (정렬: createdAt DESC) — 비공개 글은 본인만 노출
     @EntityGraph(attributePaths = {"user", "type"})
-    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT p FROM Post p "
+            + "WHERE (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "ORDER BY p.createdAt DESC")
+    Page<Post> findVisibleAll(@Param("currentUserId") Long currentUserId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"user", "type"})
-    Page<Post> findAllByTypeIdOrderByCreatedAtDesc(Long typeId, Pageable pageable);
+    @Query("SELECT p FROM Post p "
+            + "WHERE p.type.id = :typeId "
+            + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "ORDER BY p.createdAt DESC")
+    Page<Post> findVisibleByTypeId(@Param("typeId") Long typeId,
+                                   @Param("currentUserId") Long currentUserId,
+                                   Pageable pageable);
 
-    // Cursor 기반 조회 (id DESC = 최신순)
+    // Cursor 기반 (id DESC = 최신순) — 비공개 글은 본인만 노출
     @EntityGraph(attributePaths = {"user", "type"})
-    List<Post> findAllByOrderByIdDesc(Pageable pageable);
+    @Query("SELECT p FROM Post p "
+            + "WHERE (:cursorId IS NULL OR p.id < :cursorId) "
+            + "AND (:typeId IS NULL OR p.type.id = :typeId) "
+            + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+            + "ORDER BY p.id DESC")
+    List<Post> findVisibleByCursor(@Param("typeId") Long typeId,
+                                   @Param("cursorId") Long cursorId,
+                                   @Param("currentUserId") Long currentUserId,
+                                   Pageable pageable);
 
+    // 인기글 (since 이후 작성된 게시글 중 좋아요 수 많은 순)
     @EntityGraph(attributePaths = {"user", "type"})
-    List<Post> findAllByIdLessThanOrderByIdDesc(Long cursorId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"user", "type"})
-    List<Post> findAllByTypeIdOrderByIdDesc(Long typeId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"user", "type"})
-    List<Post> findAllByTypeIdAndIdLessThanOrderByIdDesc(Long typeId, Long cursorId, Pageable pageable);
+    @Query(
+            value = "SELECT p FROM Post p LEFT JOIN PostLike pl ON pl.post = p "
+                    + "WHERE p.createdAt >= :since "
+                    + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+                    + "AND (:typeId IS NULL OR p.type.id = :typeId) "
+                    + "GROUP BY p "
+                    + "ORDER BY COUNT(pl) DESC, p.id DESC",
+            countQuery = "SELECT COUNT(p) FROM Post p "
+                    + "WHERE p.createdAt >= :since "
+                    + "AND (p.isPublic = true OR (:currentUserId IS NOT NULL AND p.user.id = :currentUserId)) "
+                    + "AND (:typeId IS NULL OR p.type.id = :typeId)"
+    )
+    Page<Post> findPopularPosts(@Param("typeId") Long typeId,
+                                @Param("currentUserId") Long currentUserId,
+                                @Param("since") LocalDateTime since,
+                                Pageable pageable);
 
     List<Post> findAllByUserId(Long userId);
 

--- a/src/main/java/com/gotcha/domain/post/service/PostService.java
+++ b/src/main/java/com/gotcha/domain/post/service/PostService.java
@@ -9,10 +9,16 @@ import com.gotcha.domain.post.dto.PostCursorResponse;
 import com.gotcha.domain.post.dto.PostDetailResponse;
 import com.gotcha.domain.post.dto.PostListItemResponse;
 import com.gotcha.domain.post.dto.PostResponse;
+import com.gotcha.domain.post.dto.PostShopInfo;
+import com.gotcha.domain.post.dto.UpdatePostRequest;
+import java.time.LocalDateTime;
 import com.gotcha.domain.post.entity.Post;
 import com.gotcha.domain.post.entity.PostImage;
 import com.gotcha.domain.post.entity.PostType;
 import com.gotcha.domain.post.exception.PostException;
+import com.gotcha.domain.shop.entity.Shop;
+import com.gotcha.domain.shop.exception.ShopException;
+import com.gotcha.domain.shop.repository.ShopRepository;
 import com.gotcha.domain.post.repository.PostCommentLikeRepository;
 import com.gotcha.domain.post.repository.PostCommentRepository;
 import com.gotcha.domain.post.repository.PostImageRepository;
@@ -43,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private static final int MAX_PAGE_SIZE = 500;
+    private static final int POPULAR_PERIOD_DAYS = 7;
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
@@ -53,6 +60,7 @@ public class PostService {
     private final FileStorageService fileStorageService;
     private final SecurityUtil securityUtil;
     private final UserRepository userRepository;
+    private final ShopRepository shopRepository;
 
     private static final int MAX_IMAGES = 5;
 
@@ -73,24 +81,32 @@ public class PostService {
         PostType postType = postTypeRepository.findById(request.typeId())
                 .orElseThrow(PostException::typeNotFound);
 
-        // 4. Post 생성 및 저장
+        // 4. Shop 조회 (선택)
+        Shop shop = null;
+        if (request.shopId() != null) {
+            shop = shopRepository.findById(request.shopId())
+                    .orElseThrow(() -> ShopException.notFound(request.shopId()));
+        }
+
+        // 5. Post 생성 및 저장
         Post post = Post.builder()
                 .user(user)
                 .type(postType)
-                .title(request.title())
+                .shop(shop)
                 .content(request.content())
+                .isPublic(request.isPublic())
                 .build();
         postRepository.save(post);
 
         log.info("Post created with ID: {}", post.getId());
 
-        // 5. 이미지 저장
+        // 6. 이미지 저장
         if (request.imageUrls() != null && !request.imageUrls().isEmpty()) {
             savePostImages(post, request.imageUrls());
             log.info("Saved {} images for post {}", request.imageUrls().size(), post.getId());
         }
 
-        // 6. Response 생성
+        // 7. Response 생성
         List<PostImage> images = postImageRepository.findAllByPostIdOrderByDisplayOrder(post.getId());
         return PostResponse.from(post, images);
     }
@@ -100,6 +116,11 @@ public class PostService {
                 .orElseThrow(PostException::notFound);
 
         Long currentUserId = getCurrentUserIdOrNull();
+
+        // 비공개 게시글: 작성자 본인 또는 ADMIN만 조회 가능
+        if (!post.isPublic() && !canAccessPrivate(post, currentUserId)) {
+            throw PostException.privatePost();
+        }
 
         // 1. 이미지
         List<PostImage> images = postImageRepository.findAllByPostIdOrderByDisplayOrder(postId);
@@ -172,17 +193,61 @@ public class PostService {
         return PostDetailResponse.of(post, images, postLikeCount, isPostLiked, isOwner, commentResponses);
     }
 
+    public PostCursorResponse getPopularPosts(Long typeId, int page, int size) {
+        int effectiveSize = Math.max(1, Math.min(size, MAX_PAGE_SIZE));
+        int effectivePage = Math.max(0, page);
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(effectivePage, effectiveSize);
+
+        Long currentUserId = getCurrentUserIdOrNull();
+        LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_PERIOD_DAYS);
+
+        Page<Post> postPage = postRepository.findPopularPosts(typeId, currentUserId, since, pageable);
+        List<Post> pageContent = postPage.getContent();
+
+        if (pageContent.isEmpty()) {
+            return PostCursorResponse.of(List.of(), false);
+        }
+
+        List<Long> postIds = pageContent.stream().map(Post::getId).toList();
+
+        Map<Long, List<PostImage>> imageMap = postImageRepository
+                .findAllByPostIdInOrderByDisplayOrder(postIds)
+                .stream()
+                .collect(Collectors.groupingBy(img -> img.getPost().getId()));
+
+        Map<Long, Long> likeCountMap = postLikeRepository.countByPostIdIn(postIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PostLikeRepository.PostLikeCount::getPostId,
+                        PostLikeRepository.PostLikeCount::getLikeCount
+                ));
+
+        Map<Long, Long> commentCountMap = postCommentRepository.countByPostIdIn(postIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PostCommentRepository.PostCommentCount::getPostId,
+                        PostCommentRepository.PostCommentCount::getCommentCount
+                ));
+
+        List<PostListItemResponse> content = pageContent.stream()
+                .map(post -> PostListItemResponse.of(
+                        post,
+                        imageMap.getOrDefault(post.getId(), List.of()),
+                        likeCountMap.getOrDefault(post.getId(), 0L),
+                        commentCountMap.getOrDefault(post.getId(), 0L),
+                        currentUserId
+                ))
+                .toList();
+
+        return PostCursorResponse.of(content, postPage.hasNext());
+    }
+
     public PostCursorResponse getPostsByCursor(Long typeId, Long cursor, int size) {
         int effectiveSize = Math.max(1, Math.min(size, MAX_PAGE_SIZE));
         Pageable pageable = org.springframework.data.domain.PageRequest.of(0, effectiveSize + 1);
 
-        List<Post> posts = (typeId != null)
-                ? (cursor != null
-                        ? postRepository.findAllByTypeIdAndIdLessThanOrderByIdDesc(typeId, cursor, pageable)
-                        : postRepository.findAllByTypeIdOrderByIdDesc(typeId, pageable))
-                : (cursor != null
-                        ? postRepository.findAllByIdLessThanOrderByIdDesc(cursor, pageable)
-                        : postRepository.findAllByOrderByIdDesc(pageable));
+        Long currentUserId = getCurrentUserIdOrNull();
+        List<Post> posts = postRepository.findVisibleByCursor(typeId, cursor, currentUserId, pageable);
 
         boolean hasNext = posts.size() > effectiveSize;
         List<Post> pageContent = hasNext ? posts.subList(0, effectiveSize) : posts;
@@ -217,7 +282,8 @@ public class PostService {
                         post,
                         imageMap.getOrDefault(post.getId(), List.of()),
                         likeCountMap.getOrDefault(post.getId(), 0L),
-                        commentCountMap.getOrDefault(post.getId(), 0L)
+                        commentCountMap.getOrDefault(post.getId(), 0L),
+                        currentUserId
                 ))
                 .toList();
 
@@ -225,10 +291,11 @@ public class PostService {
     }
 
     public PageResponse<PostListItemResponse> getPosts(Long typeId, Pageable pageable) {
-        // 1. 게시글 목록 조회 (카테고리 필터)
+        Long currentUserId = getCurrentUserIdOrNull();
+        // 1. 게시글 목록 조회 (카테고리 필터 + 비공개 가시성 필터)
         Page<Post> postPage = (typeId != null)
-                ? postRepository.findAllByTypeIdOrderByCreatedAtDesc(typeId, pageable)
-                : postRepository.findAllByOrderByCreatedAtDesc(pageable);
+                ? postRepository.findVisibleByTypeId(typeId, currentUserId, pageable)
+                : postRepository.findVisibleAll(currentUserId, pageable);
 
         List<Long> postIds = postPage.getContent().stream().map(Post::getId).toList();
 
@@ -263,11 +330,64 @@ public class PostService {
                         post,
                         imageMap.getOrDefault(post.getId(), List.of()),
                         likeCountMap.getOrDefault(post.getId(), 0L),
-                        commentCountMap.getOrDefault(post.getId(), 0L)
+                        commentCountMap.getOrDefault(post.getId(), 0L),
+                        currentUserId
                 ))
                 .toList();
 
         return PageResponse.from(postPage, content);
+    }
+
+    @Transactional
+    public PostResponse updatePost(Long postId, UpdatePostRequest request) {
+        // 1. 이미지 개수 검증
+        if (request.imageUrls() != null && request.imageUrls().size() > MAX_IMAGES) {
+            throw PostException.tooManyImages();
+        }
+
+        // 2. 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostException::notFound);
+
+        // 3. 본인 확인 (ADMIN은 수정 불가, 작성자 본인만 가능)
+        User currentUser = securityUtil.getCurrentUser();
+        if (!post.getUser().getId().equals(currentUser.getId())) {
+            throw PostException.unauthorized();
+        }
+
+        // 4. PostType 조회
+        PostType postType = postTypeRepository.findById(request.typeId())
+                .orElseThrow(PostException::typeNotFound);
+
+        // 5. Shop 조회 (선택, null이면 매장 연결 해제)
+        Shop shop = null;
+        if (request.shopId() != null) {
+            shop = shopRepository.findById(request.shopId())
+                    .orElseThrow(() -> ShopException.notFound(request.shopId()));
+        }
+
+        // 6. 게시글 본문/카테고리/매장 갱신
+        post.update(postType, shop, request.content());
+
+        // 7. 이미지 교체: 기존 이미지 S3 + DB 삭제 후 신규 저장
+        List<PostImage> oldImages = postImageRepository.findAllByPostIdOrderByDisplayOrder(postId);
+        for (PostImage image : oldImages) {
+            try {
+                fileStorageService.deleteFile(image.getImageUrl());
+            } catch (Exception e) {
+                log.warn("Failed to delete post image from S3: {}", image.getImageUrl());
+            }
+        }
+        postImageRepository.deleteAllByPostId(postId);
+
+        if (request.imageUrls() != null && !request.imageUrls().isEmpty()) {
+            savePostImages(post, request.imageUrls());
+        }
+
+        log.info("Post updated - postId: {}, userId: {}", postId, currentUser.getId());
+
+        List<PostImage> newImages = postImageRepository.findAllByPostIdOrderByDisplayOrder(postId);
+        return PostResponse.from(post, newImages);
     }
 
     @Transactional
@@ -314,6 +434,29 @@ public class PostService {
             return null;
         }
         return (Long) auth.getPrincipal();
+    }
+
+    private boolean canAccessPrivate(Post post, Long currentUserId) {
+        if (currentUserId == null) {
+            return false;
+        }
+        if (post.getUser().getId().equals(currentUserId)) {
+            return true;
+        }
+        return userRepository.findById(currentUserId)
+                .map(u -> u.getUserType() == UserType.ADMIN)
+                .orElse(false);
+    }
+
+    public List<PostShopInfo> searchShopsForPost(String keyword) {
+        if (keyword == null || keyword.trim().length() < 2) {
+            return List.of();
+        }
+        List<Shop> shops = shopRepository.searchByName(
+                keyword.trim(),
+                org.springframework.data.domain.PageRequest.of(0, 50)
+        );
+        return shops.stream().map(PostShopInfo::from).toList();
     }
 
     private void savePostImages(Post post, List<String> imageUrls) {

--- a/src/main/java/com/gotcha/domain/post/service/PostService.java
+++ b/src/main/java/com/gotcha/domain/post/service/PostService.java
@@ -199,9 +199,10 @@ public class PostService {
         Pageable pageable = org.springframework.data.domain.PageRequest.of(effectivePage, effectiveSize);
 
         Long currentUserId = getCurrentUserIdOrNull();
+        boolean isAdmin = isCurrentUserAdmin(currentUserId);
         LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_PERIOD_DAYS);
 
-        Page<Post> postPage = postRepository.findPopularPosts(typeId, currentUserId, since, pageable);
+        Page<Post> postPage = postRepository.findPopularPosts(typeId, currentUserId, isAdmin, since, pageable);
         List<Post> pageContent = postPage.getContent();
 
         if (pageContent.isEmpty()) {
@@ -247,7 +248,8 @@ public class PostService {
         Pageable pageable = org.springframework.data.domain.PageRequest.of(0, effectiveSize + 1);
 
         Long currentUserId = getCurrentUserIdOrNull();
-        List<Post> posts = postRepository.findVisibleByCursor(typeId, cursor, currentUserId, pageable);
+        boolean isAdmin = isCurrentUserAdmin(currentUserId);
+        List<Post> posts = postRepository.findVisibleByCursor(typeId, cursor, currentUserId, isAdmin, pageable);
 
         boolean hasNext = posts.size() > effectiveSize;
         List<Post> pageContent = hasNext ? posts.subList(0, effectiveSize) : posts;
@@ -292,10 +294,11 @@ public class PostService {
 
     public PageResponse<PostListItemResponse> getPosts(Long typeId, Pageable pageable) {
         Long currentUserId = getCurrentUserIdOrNull();
+        boolean isAdmin = isCurrentUserAdmin(currentUserId);
         // 1. 게시글 목록 조회 (카테고리 필터 + 비공개 가시성 필터)
         Page<Post> postPage = (typeId != null)
-                ? postRepository.findVisibleByTypeId(typeId, currentUserId, pageable)
-                : postRepository.findVisibleAll(currentUserId, pageable);
+                ? postRepository.findVisibleByTypeId(typeId, currentUserId, isAdmin, pageable)
+                : postRepository.findVisibleAll(currentUserId, isAdmin, pageable);
 
         List<Long> postIds = postPage.getContent().stream().map(Post::getId).toList();
 
@@ -442,6 +445,13 @@ public class PostService {
         }
         if (post.getUser().getId().equals(currentUserId)) {
             return true;
+        }
+        return isCurrentUserAdmin(currentUserId);
+    }
+
+    private boolean isCurrentUserAdmin(Long currentUserId) {
+        if (currentUserId == null) {
+            return false;
         }
         return userRepository.findById(currentUserId)
                 .map(u -> u.getUserType() == UserType.ADMIN)

--- a/src/main/java/com/gotcha/domain/report/entity/ReportReason.java
+++ b/src/main/java/com/gotcha/domain/report/entity/ReportReason.java
@@ -68,7 +68,29 @@ public enum ReportReason {
     /** 혐오 표현 */
     USER_HATE_SPEECH(ReportTargetType.USER, "혐오 표현이 포함돼있어요"),
     /** 기타 */
-    USER_OTHER(ReportTargetType.USER, "기타");
+    USER_OTHER(ReportTargetType.USER, "기타"),
+
+    // ========== 게시글 신고 (POST) ==========
+    /** 도배/광고성 글 */
+    POST_SPAM(ReportTargetType.POST, "도배/광고성 글이에요"),
+    /** 저작권 침해 */
+    POST_COPYRIGHT(ReportTargetType.POST, "저작권을 침해해요"),
+    /** 명예 훼손 */
+    POST_DEFAMATION(ReportTargetType.POST, "명예를 훼손하는 내용이에요"),
+    /** 욕설/비방 */
+    POST_ABUSE(ReportTargetType.POST, "욕설이나 비방이 심해요"),
+    /** 폭력/위협적 내용 */
+    POST_VIOLENCE(ReportTargetType.POST, "폭력적이거나 위협적인 내용이에요"),
+    /** 외설적 내용 */
+    POST_OBSCENE(ReportTargetType.POST, "외설적인 내용이 포함돼있어요"),
+    /** 개인정보 노출 */
+    POST_PRIVACY(ReportTargetType.POST, "개인정보가 노출되어 있어요"),
+    /** 혐오 표현 */
+    POST_HATE_SPEECH(ReportTargetType.POST, "혐오 표현이 포함돼있어요"),
+    /** 허위/거짓 정보 */
+    POST_FALSE_INFO(ReportTargetType.POST, "허위/거짓 정보예요"),
+    /** 기타 */
+    POST_OTHER(ReportTargetType.POST, "기타");
 
     private final ReportTargetType targetType;
     private final String description;

--- a/src/main/java/com/gotcha/domain/report/entity/ReportTargetType.java
+++ b/src/main/java/com/gotcha/domain/report/entity/ReportTargetType.java
@@ -16,7 +16,10 @@ public enum ReportTargetType {
     SHOP_SUGGESTION("매장 정보 수정 제안"),
 
     /** 사용자 신고 */
-    USER("유저");
+    USER("유저"),
+
+    /** 커뮤니티 게시글 신고 */
+    POST("게시글");
 
     private final String description;
 

--- a/src/main/java/com/gotcha/domain/report/service/AdminReportService.java
+++ b/src/main/java/com/gotcha/domain/report/service/AdminReportService.java
@@ -7,6 +7,7 @@ import com.gotcha.domain.report.entity.Report;
 import com.gotcha.domain.report.entity.ReportStatus;
 import com.gotcha.domain.report.entity.ReportTargetType;
 import com.gotcha.domain.report.exception.ReportException;
+import com.gotcha.domain.post.repository.PostRepository;
 import com.gotcha.domain.report.repository.ReportRepository;
 import com.gotcha.domain.review.repository.ReviewRepository;
 import com.gotcha.domain.user.dto.UpdateUserStatusRequest;
@@ -28,6 +29,7 @@ public class AdminReportService {
 
     private final ReportRepository reportRepository;
     private final ReviewRepository reviewRepository;
+    private final PostRepository postRepository;
     private final AdminUserService adminUserService;
 
     /**
@@ -93,6 +95,7 @@ public class AdminReportService {
      * 신고 대상의 사용자 ID를 추출
      * - USER: targetId가 곧 userId
      * - REVIEW: 리뷰 작성자의 userId
+     * - POST: 게시글 작성자의 userId
      * - SHOP_REPORT, SHOP_SUGGESTION: 사용자 제재 대상 아님 (null 반환)
      */
     private Long resolveTargetUserId(Report report) {
@@ -100,6 +103,9 @@ public class AdminReportService {
             case USER -> report.getTargetId();
             case REVIEW -> reviewRepository.findById(report.getTargetId())
                     .map(review -> review.getUser().getId())
+                    .orElse(null);
+            case POST -> postRepository.findById(report.getTargetId())
+                    .map(post -> post.getUser().getId())
                     .orElse(null);
             case SHOP_REPORT, SHOP_SUGGESTION -> null;
         };

--- a/src/main/java/com/gotcha/domain/report/service/ReportService.java
+++ b/src/main/java/com/gotcha/domain/report/service/ReportService.java
@@ -8,6 +8,8 @@ import com.gotcha.domain.report.entity.ReportReason;
 import com.gotcha.domain.report.entity.ReportStatus;
 import com.gotcha.domain.report.entity.ReportTargetType;
 import com.gotcha.domain.report.exception.ReportException;
+import com.gotcha.domain.post.entity.Post;
+import com.gotcha.domain.post.repository.PostRepository;
 import com.gotcha.domain.report.repository.ReportRepository;
 import com.gotcha.domain.review.entity.Review;
 import com.gotcha.domain.review.repository.ReviewRepository;
@@ -33,6 +35,7 @@ public class ReportService {
     private final ReviewRepository reviewRepository;
     private final ShopRepository shopRepository;
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
     private final SecurityUtil securityUtil;
 
     /**
@@ -118,6 +121,7 @@ public class ReportService {
             case REVIEW -> validateReviewTarget(targetId, reporterId);
             case SHOP_REPORT, SHOP_SUGGESTION -> validateShopTarget(targetId);
             case USER -> validateUserTarget(targetId, reporterId);
+            case POST -> validatePostTarget(targetId, reporterId);
             default -> throw new IllegalArgumentException("Unsupported target type: " + targetType);
         }
     }
@@ -153,6 +157,18 @@ public class ReportService {
 
         if (!userRepository.existsById(userId)) {
             throw ReportException.targetNotFound("USER", userId);
+        }
+    }
+
+    /**
+     * 게시글 신고 대상 검증 (게시글 존재 여부, 본인 게시글 여부)
+     */
+    private void validatePostTarget(Long postId, Long reporterId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> ReportException.targetNotFound("POST", postId));
+
+        if (post.getUser().getId().equals(reporterId)) {
+            throw ReportException.cannotReportSelf();
         }
     }
 

--- a/src/main/java/com/gotcha/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/gotcha/domain/shop/repository/ShopRepository.java
@@ -39,6 +39,9 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
     @Query(value = "SELECT s FROM Shop s JOIN FETCH s.createdBy WHERE s.createdBy.id = :userId ORDER BY s.createdAt DESC",countQuery = "SELECT COUNT(s) FROM Shop s WHERE s.createdBy.id = :userId")
     Page<Shop> findAllByCreatedByIdWithUser(@Param("userId") Long userId, Pageable pageable);
 
+    @Query("SELECT s FROM Shop s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY s.name")
+    List<Shop> searchByName(@Param("keyword") String keyword, Pageable pageable);
+
     @Query("SELECT new com.gotcha.domain.shop.dto.DistrictClusterResponse("
             + "s.region1DepthName, s.region2DepthName, COUNT(s), AVG(s.latitude), AVG(s.longitude)) "
             + "FROM Shop s "


### PR DESCRIPTION
- 게시글에 매장 연결 추가: 선택적 shop FK, 매장 검색 API (GET /api/posts/shops/search)
- 제목(title) 필드 제거 (별도 DB 마이그레이션 필요: ALTER TABLE posts DROP COLUMN title)
- 공개/비공개 토글 추가 (isPublic): 비공개 글은 작성자/ADMIN만 조회 가능 (PT012)
- 게시글 수정 API 신규 (PUT /api/posts/{postId}): 작성자 본인만 가능
- 인기글 정렬 추가 (sort=POPULAR): 최근 7일간 좋아요 많은 순, page 기반 페이지네이션
- 목록 응답에 isOwner, authorId 추가 (햄버거 메뉴 분기용)
- 신고 도메인에 POST 타입 추가 (POST_*  사유 10종, 작성자 자동 제재 연동)
- 매장 검색: 2자 이상 키워드, 최대 50개 반환
- shopInfo 응답: 매장 미지정 시 JSON에서 필드 제외 (NON_NULL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글 검색 기능 추가
  * 게시글 수정 기능 추가
  * 게시글 공개/비공개 설정 가능
  * 최신순/인기순 정렬 옵션 추가
  * 게시글 매장 연결 기능 추가
  * 게시글 신고 기능 추가
  * 혐오 표현 신고 항목 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->