### PR TITLE
Feature/monitoring prometheus grafana

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
 	implementation 'com.bucket4j:bucket4j_jdk17-core:8.16.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql:42.7.7'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -58,12 +58,6 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-registry-prometheus'
-	// Loki logging
-	implementation 'com.github.loki4j:loki-logback-appender:2.0.3'
-	// Logback conditional (for <if> in logback-spring.xml)
-	implementation 'org.codehaus.janino:janino'
 	// Web Push
 	implementation 'nl.martijndwars:web-push:5.1.1'
 	implementation 'org.bouncycastle:bcprov-jdk18on:1.83'

--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -58,8 +58,6 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // prometheus - 설정
-                        .requestMatchers("/actuator/**").permitAll()
                         // CORS preflight (OPTIONS) must always be allowed
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Public - 인증

--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -58,6 +58,8 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // Actuator (management port only, not exposed externally)
+                        .requestMatchers("/actuator/**").permitAll()
                         // CORS preflight (OPTIONS) must always be allowed
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Public - 인증

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,8 +49,7 @@ user:
 shop:
   default-image-url: ${SHOP_DEFAULT_IMAGE_URL}
 
-# Logging Configuration (Local)
-logging:
-  loki:
-    url: ${LOKI_URL:http://localhost:3100/loki/api/v1/push}
-    enabled: ${LOKI_ENABLED:false}
+# Monitoring (Local)
+management:
+  server:
+    port: 9090

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,27 +119,12 @@ aws:
   cloudfront:
     domain: ${CLOUDFRONT_DOMAIN:}
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, metrics, prometheus
-  metrics:
-     tags:
-       application: ${spring.application.name}
-
 # Rate Limiting Configuration
 rate-limit:
   enabled: ${RATE_LIMIT_ENABLED:true}
   capacity: ${RATE_LIMIT_CAPACITY:100}
   refill-tokens: ${RATE_LIMIT_REFILL_TOKENS:100}
   refill-duration-seconds: ${RATE_LIMIT_REFILL_DURATION_SECONDS:60}
-
-# Logging Configuration
-logging:
-  loki:
-    url: ${LOKI_URL:}
-    enabled: ${LOKI_ENABLED:false}
 
 # Push Configuration
 push:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,6 +119,22 @@ aws:
   cloudfront:
     domain: ${CLOUDFRONT_DOMAIN:}
 
+# monitoring
+management:
+  server:
+    port: ${MANAGEMENT_PORT:9090}
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info, metrics
+  metrics:
+    tags:
+      application: gotcha-server
+      environment: ${SPRING_PROFILES_ACTIVE:local}
+  endpoint:
+    health:
+      show-details: always
+
 # Rate Limiting Configuration
 rate-limit:
   enabled: ${RATE_LIMIT_ENABLED:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,7 +122,7 @@ aws:
 # monitoring
 management:
   server:
-    port: ${MANAGEMENT_PORT:9090}
+    port: ${MANAGEMENT_PORT}
   endpoints:
     web:
       exposure:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,9 +2,6 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="gotcha-server"/>
-    <springProperty scope="context" name="LOKI_URL" source="logging.loki.url" defaultValue=""/>
-    <springProperty scope="context" name="LOKI_ENABLED" source="logging.loki.enabled" defaultValue="false"/>
-
     <!-- Console Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -12,37 +9,6 @@
             <charset>UTF-8</charset>
         </encoder>
     </appender>
-
-    <!-- Loki Appender (only created when LOKI_URL is set) -->
-    <if condition='!property("LOKI_URL").equals("")'>
-        <then>
-            <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-                <http>
-                    <url>${LOKI_URL}</url>
-                </http>
-                <format>
-                    <label>
-                        <pattern>app=${APP_NAME},host=${HOSTNAME},level=%level</pattern>
-                    </label>
-                    <message class="com.github.loki4j.logback.JsonLayout">
-                        <timestamp>
-                            <pattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</pattern>
-                            <timeZone>UTC</timeZone>
-                        </timestamp>
-                    </message>
-                    <sortByTime>true</sortByTime>
-                </format>
-            </appender>
-
-            <!-- Async Loki Appender for better performance -->
-            <appender name="ASYNC_LOKI" class="ch.qos.logback.classic.AsyncAppender">
-                <appender-ref ref="LOKI"/>
-                <queueSize>512</queueSize>
-                <discardingThreshold>0</discardingThreshold>
-                <neverBlock>true</neverBlock>
-            </appender>
-        </then>
-    </if>
 
     <!-- File Appender -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -90,15 +56,5 @@
         <logger name="org.hibernate" level="WARN"/>
     </springProfile>
 
-    <!-- Loki appender: conditionally added when LOKI_URL is set -->
-    <springProfile name="dev,prod">
-        <if condition='!property("LOKI_URL").equals("")'>
-            <then>
-                <root level="INFO">
-                    <appender-ref ref="ASYNC_LOKI"/>
-                </root>
-            </then>
-        </if>
-    </springProfile>
 
 </configuration>


### PR DESCRIPTION
## Summary
홈서버 이전하면서 모니터링 다시 세팅중입니다.

- 기존 모니터링 스택 제거 (Actuator, Prometheus, Loki, Janino)
- Actuator + Micrometer (Prometheus) 기반으로 모니터링 재구성
- management 포트 분리를 통해 메트릭 엔드포인트 외부 노출 방지
- 환경별 메트릭 태그 추가 (environment label)

## Changes
- build.gradle  
  - actuator, micrometer 의존성 추가  
  - loki, janino 의존성 제거  

- application.yml  
  - management 포트 분리 설정 추가  
  - 메트릭 태그(environment) 설정 추가  
  - loki 관련 설정 제거  

- SecurityConfig.java  
  - actuator endpoint permitAll 설정  

- logback-spring.xml  
  - Loki appender 제거  

## Notes
- 서버에 Prometheus + Grafana docker-compose 구성 완료 (앱 배포 후 기동 예정)
- Discord 알림 연동은 Grafana 대시보드 구성 시 별도로 진행 예정
- Log 관리를 위한 Loki 도입은 조금 나중에 할게요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 모니터링 인프라 개선: Prometheus 기반 메트릭 수집 지원 추가
  * 보안 강화: 내부 관리 엔드포인트를 별도 포트로 격리
  * 로깅 설정 단순화: 원격 로깅 설정 제거

* **Chores**
  * 빌드 의존성 업데이트 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->