### PR TITLE
feat: 매장 정보 수정 제안 사유 enum API 추가 및 WRONG_PHOTO 정리

### DIFF
--- a/src/main/java/com/gotcha/domain/shop/controller/ShopSuggestionController.java
+++ b/src/main/java/com/gotcha/domain/shop/controller/ShopSuggestionController.java
@@ -2,14 +2,17 @@ package com.gotcha.domain.shop.controller;
 
 import com.gotcha._global.common.ApiResponse;
 import com.gotcha.domain.shop.dto.CreateShopSuggestionRequest;
+import com.gotcha.domain.shop.dto.ShopSuggestReasonResponse;
 import com.gotcha.domain.shop.dto.ShopSuggestionResponse;
 import com.gotcha.domain.shop.service.ShopSuggestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShopSuggestionController {
 
     private final ShopSuggestionService shopSuggestionService;
+
+    @Operation(summary = "가게 정보 수정 제안 사유 목록 조회", description = "프론트엔드 선택지 구성용. 로그인 불필요.")
+    @GetMapping("/suggest-reasons")
+    public ApiResponse<List<ShopSuggestReasonResponse>> getSuggestReasons() {
+        return ApiResponse.success(ShopSuggestReasonResponse.getAllReasons());
+    }
 
     @Operation(summary = "가게 정보 수정 제안", description = "복수 선택 가능. 로그인 필요.")
     @PostMapping("/{shopId}/suggest")

--- a/src/main/java/com/gotcha/domain/shop/dto/ShopSuggestReasonResponse.java
+++ b/src/main/java/com/gotcha/domain/shop/dto/ShopSuggestReasonResponse.java
@@ -1,0 +1,30 @@
+package com.gotcha.domain.shop.dto;
+
+import com.gotcha.domain.shop.entity.SuggestionReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 가게 정보 수정 제안 사유 목록 응답 DTO
+ * - 프론트엔드에서 제안 사유 선택지를 동적으로 구성하기 위해 사용
+ */
+@Schema(description = "가게 정보 수정 제안 사유 항목")
+public record ShopSuggestReasonResponse(
+        @Schema(description = "제안 사유 코드", example = "WRONG_ADDRESS")
+        String code,
+
+        @Schema(description = "제안 사유 설명 (사용자에게 표시)", example = "주소 정보가 잘못됐어요")
+        String description
+) {
+
+    public static ShopSuggestReasonResponse from(SuggestionReason reason) {
+        return new ShopSuggestReasonResponse(reason.name(), reason.getDescription());
+    }
+
+    public static List<ShopSuggestReasonResponse> getAllReasons() {
+        return Arrays.stream(SuggestionReason.values())
+                .map(ShopSuggestReasonResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/gotcha/domain/shop/entity/SuggestionReason.java
+++ b/src/main/java/com/gotcha/domain/shop/entity/SuggestionReason.java
@@ -1,9 +1,9 @@
 package com.gotcha.domain.shop.entity;
 
 public enum SuggestionReason {
-    WRONG_ADDRESS("잘못된 주소예요"),
-    WRONG_PHOTO("매장 사진이 달라요"),
+    WRONG_ADDRESS("주소 정보가 잘못됐어요"),
     WRONG_LOCATION_HINT("매장 위치힌트가 달라요"),
+    BUSINESS_CLOSED("영업 종료/폐업된 매장이에요"),
     WRONG_BUSINESS_HOURS("영업시간 정보가 달라요"),
     WRONG_PAYMENT_INFO("카드 결제/ATM 등 결제 정보가 달라요"),
     OTHER("기타");

--- a/src/main/resources/db/migration/V6__remove_wrong_photo_suggestion_reason.sql
+++ b/src/main/resources/db/migration/V6__remove_wrong_photo_suggestion_reason.sql
@@ -1,0 +1,13 @@
+-- WRONG_PHOTO 제안 사유 제거 (피그마 디자인 변경에 따라 옵션에서 제외)
+-- 1) WRONG_PHOTO만 단독으로 가진 제안 → 의미 없는 빈 reasons가 남지 않도록 제안 자체를 삭제
+--    (shop_suggestion_reasons는 ON DELETE CASCADE이므로 자동 정리됨)
+DELETE FROM shop_suggestions
+WHERE id IN (
+    SELECT suggestion_id
+    FROM shop_suggestion_reasons
+    GROUP BY suggestion_id
+    HAVING COUNT(*) = 1 AND MAX(reason) = 'WRONG_PHOTO'
+);
+
+-- 2) 다른 사유와 함께 등록된 WRONG_PHOTO 행만 제거
+DELETE FROM shop_suggestion_reasons WHERE reason = 'WRONG_PHOTO';


### PR DESCRIPTION
- GET /api/shops/suggest-reasons 엔드포인트 추가 (ShopSuggestReasonResponse)
- SuggestionReason: WRONG_PHOTO 제거, BUSINESS_CLOSED 추가, 라벨/순서 피그마와 일치
- V6 Flyway 마이그레이션: shop_suggestion_reasons의 WRONG_PHOTO 레코드 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 가게 정보 수정 제안 사유 목록을 조회하는 새로운 API 엔드포인트 추가
  * 사용자에게 제공되는 제안 사유 목록 업데이트

* **Chores**
  * 제안 사유 관련 데이터 정리 및 마이그레이션 적용
  * 제안 사유 설명 문구 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->