### PR TITLE
feat: 내가 제보한 매장 목록 좋아요순(찜 수) 정렬 추가

### DIFF
--- a/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
@@ -59,6 +60,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.warn("Type mismatch: {}", e.getMessage());
+        Class<?> requiredType = e.getRequiredType();
+        String message = requiredType != null && requiredType.isEnum()
+                ? e.getName() + ": 허용된 값은 " + java.util.Arrays.toString(requiredType.getEnumConstants()) + " 입니다"
+                : e.getName() + ": 유효하지 않은 값입니다";
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(CommonErrorCode.INVALID_VALUE, message));
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)

--- a/src/main/java/com/gotcha/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/gotcha/domain/shop/repository/ShopRepository.java
@@ -39,6 +39,13 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
     @Query(value = "SELECT s FROM Shop s JOIN FETCH s.createdBy WHERE s.createdBy.id = :userId ORDER BY s.createdAt DESC",countQuery = "SELECT COUNT(s) FROM Shop s WHERE s.createdBy.id = :userId")
     Page<Shop> findAllByCreatedByIdWithUser(@Param("userId") Long userId, Pageable pageable);
 
+    @Query(
+            value = "SELECT s FROM Shop s JOIN FETCH s.createdBy WHERE s.createdBy.id = :userId "
+                    + "ORDER BY (SELECT COUNT(f.id) FROM Favorite f WHERE f.shop = s) DESC, s.createdAt DESC",
+            countQuery = "SELECT COUNT(s) FROM Shop s WHERE s.createdBy.id = :userId"
+    )
+    Page<Shop> findAllByCreatedByIdWithUserOrderByFavoriteCount(@Param("userId") Long userId, Pageable pageable);
+
     @Query("SELECT s FROM Shop s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY s.name")
     List<Shop> searchByName(@Param("keyword") String keyword, Pageable pageable);
 

--- a/src/main/java/com/gotcha/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.favorite.service.FavoriteService;
 import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
+import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
 import com.gotcha.domain.user.dto.UpdateProfileImageRequest;
 import com.gotcha.domain.user.dto.UserNicknameResponse;
@@ -57,10 +58,11 @@ public class UserController implements UserControllerApi {
     @GetMapping("/me/shops")
     public ApiResponse<PageResponse<MyShopResponse>> getMyShops(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "LATEST") MyShopSortType sortBy
     ) {
         Pageable pageable = PageRequest.of(page, size);
-        return ApiResponse.success(userService.getMyShops(pageable));
+        return ApiResponse.success(userService.getMyShops(sortBy, pageable));
     }
 
     @Override

--- a/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
@@ -5,6 +5,7 @@ import com.gotcha._global.common.PageResponse;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
+import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
 import com.gotcha.domain.user.dto.UpdateProfileImageRequest;
 import com.gotcha.domain.user.dto.UserNicknameResponse;
@@ -167,7 +168,7 @@ public interface UserControllerApi {
 
     @Operation(
             summary = "내가 제보한 가게 목록 조회",
-            description = "현재 로그인한 사용자가 제보한 가게 목록을 최신순으로 조회합니다.",
+            description = "현재 로그인한 사용자가 제보한 가게 목록을 조회합니다. sortBy=LATEST(최신순, 기본값) 또는 sortBy=FAVORITE_COUNT(좋아요순).",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -221,7 +222,8 @@ public interface UserControllerApi {
     })
     ApiResponse<PageResponse<MyShopResponse>> getMyShops(
             @RequestParam(defaultValue = "0") @Min(0) int page,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "LATEST") MyShopSortType sortBy
     );
 
     @Operation(

--- a/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
@@ -201,6 +201,25 @@ public interface UserControllerApi {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - sortBy 파라미터 값이 MyShopSortType(LATEST, FAVORITE_COUNT) enum과 일치하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "VAL_003 - sortBy enum 변환 실패",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "VAL_003",
+                                                "message": "sortBy: 허용된 값은 [LATEST, FAVORITE_COUNT] 입니다"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
                     description = "인증 실패",
                     content = @Content(

--- a/src/main/java/com/gotcha/domain/user/dto/MyShopSortType.java
+++ b/src/main/java/com/gotcha/domain/user/dto/MyShopSortType.java
@@ -1,0 +1,12 @@
+package com.gotcha.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내가 제보한 가게 정렬 타입")
+public enum MyShopSortType {
+    @Schema(description = "최신순")
+    LATEST,
+
+    @Schema(description = "좋아요순 (찜한 사용자 수 기준)")
+    FAVORITE_COUNT
+}

--- a/src/main/java/com/gotcha/domain/user/service/UserService.java
+++ b/src/main/java/com/gotcha/domain/user/service/UserService.java
@@ -29,6 +29,7 @@ import com.gotcha.domain.shop.repository.ShopRepository;
 import com.gotcha.domain.shop.service.ShopService;
 import com.gotcha.domain.user.dto.MyInfoResponse;
 import com.gotcha.domain.user.dto.MyShopResponse;
+import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UserNicknameResponse;
 import com.gotcha.domain.user.dto.UserResponse;
 import com.gotcha.domain.user.dto.WithdrawalRequest;
@@ -104,13 +105,16 @@ public class UserService {
 
     /**
      * 내가 제보한 가게 목록 조회
+     * @param sortBy 정렬 기준 (LATEST: 최신순, FAVORITE_COUNT: 좋아요순)
      * @param pageable 페이징 정보
      * @return 내가 제보한 가게 목록
      */
-    public PageResponse<MyShopResponse> getMyShops(Pageable pageable) {
+    public PageResponse<MyShopResponse> getMyShops(MyShopSortType sortBy, Pageable pageable) {
         Long userId = securityUtil.getCurrentUserId();
 
-        Page<Shop> shopPage = shopRepository.findAllByCreatedByIdWithUser(userId, pageable);
+        Page<Shop> shopPage = sortBy == MyShopSortType.FAVORITE_COUNT
+                ? shopRepository.findAllByCreatedByIdWithUserOrderByFavoriteCount(userId, pageable)
+                : shopRepository.findAllByCreatedByIdWithUser(userId, pageable);
 
         List<MyShopResponse> content = shopPage.getContent().stream()
                 .map(shop -> {


### PR DESCRIPTION
## Summary
- `GET /api/users/me/shops`에 `sortBy` 쿼리 파라미터 추가 (`LATEST` | `FAVORITE_COUNT`, 기본 `LATEST`)
- `FAVORITE_COUNT`일 때 상관 서브쿼리로 찜 수 기준 정렬, 동률 시 `createdAt DESC` 보조 정렬
- `MyShopSortType` enum 신규 추가

## Test plan
- [ ] `?sortBy=LATEST` 요청 시 기존과 동일하게 최신순으로 응답하는지
- [ ] `?sortBy=FAVORITE_COUNT` 요청 시 찜 수 많은 가게가 먼저 오는지
- [ ] 찜 수가 같은 가게는 최신순으로 오는지
- [ ] `sortBy` 미지정 시 기본 `LATEST` 동작 확인
- [ ] 잘못된 값 (`?sortBy=FOO`) 입력 시 400 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 내 가게 목록 정렬 기능이 추가되었습니다. 최신순(기본값) 또는 좋아요순으로 정렬 옵션을 선택할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->