### PR TITLE
feat: 내가 작성한 리뷰 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/gotcha/domain/review/repository/ReviewRepository.java
@@ -39,6 +39,23 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     boolean existsByUserIdAndShopId(Long userId, Long shopId);
 
+    @Query(
+            value = "SELECT r FROM Review r JOIN FETCH r.shop WHERE r.user.id = :userId "
+                    + "ORDER BY r.createdAt DESC",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.user.id = :userId"
+    )
+    Page<Review> findAllByUserIdWithShopOrderByCreatedAtDesc(
+            @Param("userId") Long userId, Pageable pageable);
+
+    @Query(
+            value = "SELECT r FROM Review r JOIN FETCH r.shop WHERE r.user.id = :userId "
+                    + "ORDER BY (SELECT COUNT(rl.id) FROM ReviewLike rl WHERE rl.review.id = r.id) DESC, "
+                    + "r.createdAt DESC",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.user.id = :userId"
+    )
+    Page<Review> findAllByUserIdWithShopOrderByLikeCountDesc(
+            @Param("userId") Long userId, Pageable pageable);
+
     List<Review> findAllByUserId(Long userId);
 
     List<Review> findAllByShopId(Long shopId);

--- a/src/main/java/com/gotcha/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import com.gotcha.domain.auth.util.CookieUtils;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.favorite.service.FavoriteService;
 import com.gotcha.domain.user.dto.MyInfoResponse;
+import com.gotcha.domain.user.dto.MyReviewResponse;
+import com.gotcha.domain.user.dto.MyReviewSortType;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
@@ -63,6 +65,17 @@ public class UserController implements UserControllerApi {
     ) {
         Pageable pageable = PageRequest.of(page, size);
         return ApiResponse.success(userService.getMyShops(sortBy, pageable));
+    }
+
+    @Override
+    @GetMapping("/me/reviews")
+    public ApiResponse<PageResponse<MyReviewResponse>> getMyReviews(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "LATEST") MyReviewSortType sortBy
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ApiResponse.success(userService.getMyReviews(sortBy, pageable));
     }
 
     @Override

--- a/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
+++ b/src/main/java/com/gotcha/domain/user/controller/UserControllerApi.java
@@ -4,6 +4,8 @@ import com.gotcha._global.common.ApiResponse;
 import com.gotcha._global.common.PageResponse;
 import com.gotcha.domain.favorite.dto.FavoriteShopResponse;
 import com.gotcha.domain.user.dto.MyInfoResponse;
+import com.gotcha.domain.user.dto.MyReviewResponse;
+import com.gotcha.domain.user.dto.MyReviewSortType;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UpdateNicknameRequest;
@@ -243,6 +245,87 @@ public interface UserControllerApi {
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "LATEST") MyShopSortType sortBy
+    );
+
+    @Operation(
+            summary = "내가 작성한 리뷰 목록 조회",
+            description = "현재 로그인한 사용자가 작성한 리뷰 목록을 조회합니다. sortBy=LATEST(최신순, 기본값) 또는 sortBy=LIKE_COUNT(좋아요순).",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "content": [
+                                          {
+                                            "id": 1,
+                                            "shopId": 5,
+                                            "shopName": "가챠샵 신사점",
+                                            "content": "리뷰 내용입니다",
+                                            "imageUrls": ["https://..."],
+                                            "likeCount": 2,
+                                            "isLiked": false,
+                                            "createdAt": "2026-01-01T10:30:00"
+                                          }
+                                        ],
+                                        "totalCount": 1,
+                                        "page": 0,
+                                        "size": 20,
+                                        "hasNext": false
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - sortBy 파라미터 값이 MyReviewSortType(LATEST, LIKE_COUNT) enum과 일치하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "VAL_003 - sortBy enum 변환 실패",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "VAL_003",
+                                                "message": "sortBy: 허용된 값은 [LATEST, LIKE_COUNT] 입니다"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "A001 - 토큰 없음",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "A001",
+                                                "message": "로그인이 필요합니다"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<PageResponse<MyReviewResponse>> getMyReviews(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "LATEST") MyReviewSortType sortBy
     );
 
     @Operation(

--- a/src/main/java/com/gotcha/domain/user/dto/MyReviewResponse.java
+++ b/src/main/java/com/gotcha/domain/user/dto/MyReviewResponse.java
@@ -1,0 +1,52 @@
+package com.gotcha.domain.user.dto;
+
+import com.gotcha.domain.review.entity.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "내가 작성한 리뷰 응답")
+public record MyReviewResponse(
+    @Schema(description = "리뷰 ID", example = "1")
+    Long id,
+
+    @Schema(description = "가게 ID", example = "5")
+    Long shopId,
+
+    @Schema(description = "가게명", example = "가챠샵 신사점")
+    String shopName,
+
+    @Schema(description = "리뷰 내용")
+    String content,
+
+    @Schema(description = "리뷰 이미지 URL 목록")
+    List<String> imageUrls,
+
+    @Schema(description = "좋아요 수", example = "12")
+    Long likeCount,
+
+    @Schema(description = "내가 좋아요 눌렀는지 여부", example = "false")
+    boolean isLiked,
+
+    @Schema(description = "작성 일시", example = "2025-01-01T10:30:00")
+    LocalDateTime createdAt
+) {
+    public static MyReviewResponse from(
+            Review review,
+            List<String> imageUrls,
+            Long likeCount,
+            boolean isLiked
+    ) {
+        return new MyReviewResponse(
+            review.getId(),
+            review.getShop().getId(),
+            review.getShop().getName(),
+            review.getContent(),
+            imageUrls,
+            likeCount,
+            isLiked,
+            review.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/gotcha/domain/user/dto/MyReviewSortType.java
+++ b/src/main/java/com/gotcha/domain/user/dto/MyReviewSortType.java
@@ -1,0 +1,12 @@
+package com.gotcha.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내가 작성한 리뷰 정렬 타입")
+public enum MyReviewSortType {
+    @Schema(description = "최신순")
+    LATEST,
+
+    @Schema(description = "좋아요순")
+    LIKE_COUNT
+}

--- a/src/main/java/com/gotcha/domain/user/service/UserService.java
+++ b/src/main/java/com/gotcha/domain/user/service/UserService.java
@@ -28,6 +28,8 @@ import com.gotcha.domain.shop.repository.ShopSuggestionRepository;
 import com.gotcha.domain.shop.repository.ShopRepository;
 import com.gotcha.domain.shop.service.ShopService;
 import com.gotcha.domain.user.dto.MyInfoResponse;
+import com.gotcha.domain.user.dto.MyReviewResponse;
+import com.gotcha.domain.user.dto.MyReviewSortType;
 import com.gotcha.domain.user.dto.MyShopResponse;
 import com.gotcha.domain.user.dto.MyShopSortType;
 import com.gotcha.domain.user.dto.UserNicknameResponse;
@@ -39,7 +41,10 @@ import com.gotcha.domain.user.exception.UserException;
 import com.gotcha.domain.user.repository.UserPermissionRepository;
 import com.gotcha.domain.user.repository.UserRepository;
 import com.gotcha.domain.user.repository.WithdrawalSurveyRepository;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -126,6 +131,61 @@ public class UserService {
                 .collect(Collectors.toList());
 
         return PageResponse.from(shopPage, content);
+    }
+
+    /**
+     * 내가 작성한 리뷰 목록 조회
+     * @param sortBy 정렬 기준 (LATEST: 최신순, LIKE_COUNT: 좋아요순)
+     * @param pageable 페이징 정보
+     * @return 내가 작성한 리뷰 목록
+     */
+    public PageResponse<MyReviewResponse> getMyReviews(MyReviewSortType sortBy, Pageable pageable) {
+        Long userId = securityUtil.getCurrentUserId();
+
+        Page<Review> reviewPage = sortBy == MyReviewSortType.LIKE_COUNT
+                ? reviewRepository.findAllByUserIdWithShopOrderByLikeCountDesc(userId, pageable)
+                : reviewRepository.findAllByUserIdWithShopOrderByCreatedAtDesc(userId, pageable);
+
+        List<Review> reviews = reviewPage.getContent();
+        if (reviews.isEmpty()) {
+            return PageResponse.from(reviewPage, List.of());
+        }
+
+        List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
+
+        // 이미지 일괄 조회 (N+1 방지)
+        Map<Long, List<String>> imageUrlsByReviewId = reviewImageRepository
+                .findAllByReviewIdInOrderByReviewIdAscDisplayOrderAsc(reviewIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        ri -> ri.getReview().getId(),
+                        Collectors.mapping(ReviewImage::getImageUrl, Collectors.toList())
+                ));
+
+        // 좋아요 수 일괄 조회 (N+1 방지)
+        Map<Long, Long> likeCountByReviewId = reviewLikeRepository
+                .countByReviewIdInGroupByReviewId(reviewIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ReviewLikeRepository.ReviewLikeCount::getReviewId,
+                        ReviewLikeRepository.ReviewLikeCount::getLikeCount
+                ));
+
+        // 내가 좋아요 한 리뷰 ID 일괄 조회 (N+1 방지)
+        Set<Long> likedReviewIds = Set.copyOf(
+                reviewLikeRepository.findLikedReviewIds(userId, reviewIds)
+        );
+
+        List<MyReviewResponse> content = reviews.stream()
+                .map(review -> MyReviewResponse.from(
+                        review,
+                        imageUrlsByReviewId.getOrDefault(review.getId(), Collections.emptyList()),
+                        likeCountByReviewId.getOrDefault(review.getId(), 0L),
+                        likedReviewIds.contains(review.getId())
+                ))
+                .collect(Collectors.toList());
+
+        return PageResponse.from(reviewPage, content);
     }
 
     /**


### PR DESCRIPTION
GET /api/users/me/reviews 엔드포인트를 신설해 마이페이지 '작성한 리뷰' 화면에 필요한 데이터를 제공합니다.

- 정렬 옵션: LATEST(기본) | LIKE_COUNT
- 응답: 리뷰 ID, 가게 ID/이름, 본문, 이미지, 좋아요 수/여부, 작성일시
- N+1 방지: 이미지/좋아요 수/내 좋아요 ID를 일괄 조회 후 조립
- ReviewRepository에 Shop FETCH JOIN 쿼리 2종 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자가 자신이 작성한 리뷰 목록을 조회할 수 있는 기능이 추가되었습니다.
  * 리뷰 목록을 최신순 또는 좋아요순으로 정렬하여 조회 가능합니다.
  * 페이지네이션을 지원하여 리뷰를 효율적으로 탐색할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->