### PR TITLE
feat: 게시글 상세 응답에 작성자 프로필 이미지 URL 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/gotcha/domain/post/dto/PostDetailResponse.java
@@ -22,6 +22,9 @@ public record PostDetailResponse(
         @Schema(description = "작성자 닉네임", example = "빨간캡슐#21")
         String authorNickname,
 
+        @Schema(description = "작성자 프로필 이미지 URL (없을 경우 null)", example = "https://cdn.example.com/profile/1.png")
+        String authorProfileImageUrl,
+
         @Schema(description = "본문 내용", example = "오늘 드디어 원하던 캐릭터를 뽑았어요!")
         String content,
 
@@ -63,6 +66,7 @@ public record PostDetailResponse(
                 post.getType().getId(),
                 post.getType().getTypeName(),
                 post.getUser().getNickname(),
+                post.getUser().getProfileImageUrl(),
                 post.getContent(),
                 images.stream().map(PostImage::getImageUrl).toList(),
                 post.getShop() != null ? PostShopInfo.from(post.getShop()) : null,


### PR DESCRIPTION
PostDetailResponse에 authorProfileImageUrl 필드를 추가하여 게시글 상세 페이지에서 작성자 프로필 이미지를 노출할 수 있도록 함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 상세 정보 응답에 작성자의 프로필 이미지 URL이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->