### PR TITLE
fix: 프로필 이미지 URL 검증 정규식 제거 (CloudFront URL 지원)

### DIFF
--- a/src/main/java/com/gotcha/domain/user/dto/UpdateProfileImageRequest.java
+++ b/src/main/java/com/gotcha/domain/user/dto/UpdateProfileImageRequest.java
@@ -2,7 +2,6 @@ package com.gotcha.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 @Schema(description = "프로필 이미지 변경 요청")
 public record UpdateProfileImageRequest(
@@ -10,8 +9,6 @@ public record UpdateProfileImageRequest(
                 example = "https://gotcha-prod-files.s3.ap-northeast-2.amazonaws.com/prod/profiles/abc-123.webp",
                 required = true)
         @NotBlank(message = "프로필 이미지 URL은 필수입니다")
-        @Pattern(regexp = "^https://(storage\\.googleapis\\.com/.*|[^/]+\\.s3\\.[^/]+\\.amazonaws\\.com/.*)$",
-                 message = "올바른 클라우드 스토리지 URL 형식이 아닙니다")
         String profileImageUrl
 ) {
 }

--- a/src/test/java/com/gotcha/domain/user/dto/UpdateProfileImageRequestTest.java
+++ b/src/test/java/com/gotcha/domain/user/dto/UpdateProfileImageRequestTest.java
@@ -67,20 +67,18 @@ class UpdateProfileImageRequestTest {
     }
 
     @Test
-    @DisplayName("잘못된 URL 형식은 거부된다")
-    void invalidUrlIsRejected() {
+    @DisplayName("CloudFront URL도 유효하다")
+    void cloudfrontUrlIsValid() {
         // given
         UpdateProfileImageRequest request = new UpdateProfileImageRequest(
-                "https://example.com/image.jpg"
+                "https://d1234abcd.cloudfront.net/profiles/uuid.webp"
         );
 
         // when
         Set<ConstraintViolation<UpdateProfileImageRequest>> violations = validator.validate(request);
 
         // then
-        assertThat(violations).hasSize(1);
-        assertThat(violations.iterator().next().getMessage())
-                .isEqualTo("올바른 클라우드 스토리지 URL 형식이 아닙니다");
+        assertThat(violations).isEmpty();
     }
 
     @Test
@@ -93,23 +91,8 @@ class UpdateProfileImageRequestTest {
         Set<ConstraintViolation<UpdateProfileImageRequest>> violations = validator.validate(request);
 
         // then
-        assertThat(violations).hasSize(2); // @NotBlank + @Pattern
-    }
-
-    @Test
-    @DisplayName("http URL은 거부된다 (https만 허용)")
-    void httpUrlIsRejected() {
-        // given
-        UpdateProfileImageRequest request = new UpdateProfileImageRequest(
-                "http://storage.googleapis.com/bucket/file.jpg"
-        );
-
-        // when
-        Set<ConstraintViolation<UpdateProfileImageRequest>> violations = validator.validate(request);
-
-        // then
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage())
-                .isEqualTo("올바른 클라우드 스토리지 URL 형식이 아닙니다");
+                .isEqualTo("프로필 이미지 URL은 필수입니다");
     }
 }


### PR DESCRIPTION
S3FileUploadService가 CLOUDFRONT_DOMAIN 환경변수가 설정된 경우 https://{cloudfrontDomain}/{key} 형식의 URL을 반환하는데,
UpdateProfileImageRequest의 @Pattern 정규식은 GCS와 S3 도메인만 허용하여 PATCH /api/users/me/profile-image 호출 시 400 에러가 발생.

이미지 URL은 백엔드 업로드 API가 발급한 값을 그대로 전달하는 흐름이고,
다른 도메인(shop, review, post)의 이미지 필드에도 동일한 검증이 없어
일관성 확보를 위해 @Pattern을 제거.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 프로필 이미지 URL 입력 검증이 개선되었습니다.
  * URL 형식 제한이 완화되어 더 다양한 이미지 소스 사용이 가능합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->