### PR TITLE
fix: 가게 상세 응답에서 기본 이미지일 경우 mainImageUrl을 null로 반환

### DIFF
--- a/src/main/java/com/gotcha/domain/shop/dto/ShopDetailResponse.java
+++ b/src/main/java/com/gotcha/domain/shop/dto/ShopDetailResponse.java
@@ -65,12 +65,15 @@ public record ShopDetailResponse(
      * @param reviewCount            전체 리뷰 개수
      * @param totalReviewImageCount  전체 리뷰 사진 개수
      * @param recentReviewImages     최신 리뷰 이미지 4개
+     * @param defaultImageUrl        기본 매장 이미지 URL (이 값과 일치하면 mainImageUrl은 null로 응답)
      * @return ShopDetailResponse
      */
     public static ShopDetailResponse of(Shop shop, String todayOpenTime, String openStatus, Boolean isFavorite,
                                         List<ReviewResponse> reviews, Long reviewCount, Long totalReviewImageCount,
-                                        List<String> recentReviewImages) {
+                                        List<String> recentReviewImages, String defaultImageUrl) {
         Objects.requireNonNull(shop, "Shop must not be null");
+
+        String mainImageUrl = Objects.equals(shop.getMainImageUrl(), defaultImageUrl) ? null : shop.getMainImageUrl();
 
         return new ShopDetailResponse(
                 shop.getId(),
@@ -82,7 +85,7 @@ public record ShopDetailResponse(
                 openStatus,
                 shop.getLatitude(),
                 shop.getLongitude(),
-                shop.getMainImageUrl(),
+                mainImageUrl,
                 isFavorite,
                 reviews != null ? reviews : Collections.emptyList(),
                 reviewCount,

--- a/src/main/java/com/gotcha/domain/shop/service/ShopService.java
+++ b/src/main/java/com/gotcha/domain/shop/service/ShopService.java
@@ -533,7 +533,7 @@ public class ShopService {
 
         log.info("shop-detail cache miss - shopId: {}, sortBy: {}", shopId, sortBy);
         return ShopDetailResponse.of(shop, todayOpenTime, openStatus, false,
-                reviews, reviewCount, totalReviewImageCount, recentReviewImages);
+                reviews, reviewCount, totalReviewImageCount, recentReviewImages, defaultShopImageUrl);
     }
 
     /**


### PR DESCRIPTION
가게 생성 시 mainImageUrl이 없으면 기본 이미지 URL이 DB에 저장되는데,
응답에 그대로 내려가다 보니 프론트가 매장 사진 개수를 계산할 때
기본 이미지도 1장으로 카운트되는 이슈가 발생.

ShopDetailResponse.of()에 defaultImageUrl 파라미터를 받아 동일한 경우 null로 치환하여 프론트의 null 체크 로직과 자연스럽게 맞물리도록 수정.

영향 범위: GET /api/shops/{id} (가게 상세 조회).
다른 응답 DTO들(ShopResponse, ShopMapResponse 등)은 썸네일 표시 용도라 기존 동작 유지가 안전하다고 판단해 이번 변경에서 제외.