### PR TITLE
fix: 매장 등록 시 내가 제보한 매장에 안 보이는 버그 수정

### DIFF
--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -90,9 +90,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/dev/**").permitAll()
                         // Authenticated - 사용자
                         .requestMatchers("/api/users/**").authenticated()
-                        // Authenticated - 가게 생성/제보 (로그인 필수)
+                        // Authenticated - 가게 생성 (로그인 필수)
                         .requestMatchers(HttpMethod.POST, "/api/shops/save").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/api/shops/report").authenticated()
                         // Public - file upload (used by reviews, reports, etc.)
                         .requestMatchers(HttpMethod.POST, "/api/files/**").permitAll()
                         // Public - Push VAPID key

--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -90,9 +90,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/dev/**").permitAll()
                         // Authenticated - 사용자
                         .requestMatchers("/api/users/**").authenticated()
-                        // Public - 가게 생성/제보 (비회원도 가능)
-                        .requestMatchers(HttpMethod.POST, "/api/shops/save").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/shops/report").permitAll()
+                        // Authenticated - 가게 생성/제보 (로그인 필수)
+                        .requestMatchers(HttpMethod.POST, "/api/shops/save").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/shops/report").authenticated()
                         // Public - file upload (used by reviews, reports, etc.)
                         .requestMatchers(HttpMethod.POST, "/api/files/**").permitAll()
                         // Public - Push VAPID key

--- a/src/main/java/com/gotcha/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/gotcha/domain/shop/controller/ShopController.java
@@ -1,6 +1,7 @@
 package com.gotcha.domain.shop.controller;
 
 import com.gotcha._global.common.ApiResponse;
+import com.gotcha.domain.auth.exception.AuthException;
 import com.gotcha.domain.favorite.dto.FavoriteResponse;
 import com.gotcha.domain.favorite.service.FavoriteService;
 import com.gotcha.domain.review.dto.ReviewSortType;
@@ -200,7 +201,7 @@ public class ShopController implements ShopControllerApi {
     private User getCurrentUserOrThrow() {
         User user = getCurrentUser();
         if (user == null) {
-            throw new IllegalStateException("로그인이 필요합니다");
+            throw AuthException.unauthorized();
         }
         return user;
     }

--- a/src/main/java/com/gotcha/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/gotcha/domain/shop/controller/ShopController.java
@@ -54,7 +54,7 @@ public class ShopController implements ShopControllerApi {
             @Valid @RequestBody CreateShopRequest request,
             @Valid @ModelAttribute CoordinateRequest coordinate
     ) {
-        User currentUser = getCurrentUser();
+        User currentUser = getCurrentUserOrThrow();
 
         Shop shop = shopService.createShop(
                 request.name(),

--- a/src/test/java/com/gotcha/domain/shop/controller/ShopControllerTest.java
+++ b/src/test/java/com/gotcha/domain/shop/controller/ShopControllerTest.java
@@ -86,7 +86,7 @@ class ShopControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
-                    .andExpect(status().isInternalServerError());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/gotcha/domain/shop/controller/ShopControllerTest.java
+++ b/src/test/java/com/gotcha/domain/shop/controller/ShopControllerTest.java
@@ -3,7 +3,6 @@ package com.gotcha.domain.shop.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -70,8 +69,8 @@ class ShopControllerTest {
     class SaveShop {
 
         @Test
-        @DisplayName("비회원도 가게를 생성할 수 있다 (createdBy = null)")
-        void shouldAllowNonMemberToCreateShop() throws Exception {
+        @DisplayName("비로그인 시 가게 생성이 거부된다")
+        void shouldRejectNonMemberShopCreation() throws Exception {
             // given
             CreateShopRequest request = new CreateShopRequest(
                     "테스트 가게",
@@ -80,18 +79,6 @@ class ShopControllerTest {
                     Map.of("Mon", "10:00-22:00")
             );
 
-            Shop shop = createShop(1L, "테스트 가게", null);
-
-            given(shopService.createShop(
-                    anyString(),
-                    anyDouble(),
-                    anyDouble(),
-                    anyString(),
-                    anyString(),
-                    any(),
-                    isNull()
-            )).willReturn(shop);
-
             // when & then
             mockMvc.perform(post("/api/shops/save")
                             .param("latitude", "37.5172")
@@ -99,10 +86,7 @@ class ShopControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.id").value(1))
-                    .andExpect(jsonPath("$.data.name").value("테스트 가게"));
+                    .andExpect(status().isInternalServerError());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- 매장 등록 API(`POST /api/shops/save`)를 `permitAll()` → `authenticated()`로 변경
- `ShopController.saveShop()`에서 `getCurrentUser()` → `getCurrentUserOrThrow()`로 변경

## Background
매장 등록 후 "내가 제보한 매장" 목록에 해당 매장이 표시되지 않는 버그 수정

### 원인
1. `POST /api/shops/save`가 `permitAll()`이라 만료된 JWT로 요청해도 401이 아닌 201 반환
2. 만료된 토큰 → `JwtAuthenticationFilter`에서 SecurityContext 미설정 → `getCurrentUser()` null 반환
3. Shop이 `createdBy = null`로 저장됨
4. "내가 제보한 매장" 쿼리가 `JOIN FETCH`(INNER JOIN)이라 `createdBy = null`인 매장은 조회 불가
5. 프론트엔드는 201 응답을 받으므로 토큰 갱신 로직이 트리거되지 않음

### 수정
- `SecurityConfig`: 매장 등록/제보 엔드포인트를 `authenticated()`로 변경하여 만료 토큰 시 401 반환 → 프론트엔드 자동 토큰 갱신 유도
- `ShopController`: `getCurrentUserOrThrow()` 사용으로 이중 안전장치 추가

### 추가
- 이건 코드랑 별개로 JWT Refresh 토큰의 기간을 너무 짧게 준 것 같아서 조금 길게 바꿨습니다 (로그인 길게 유지)

## Test plan
- [ ] 로그인 상태에서 매장 등록 후 "내가 제보한 매장" 목록에 표시되는지 확인
- [ ] 토큰 만료 상태에서 매장 등록 시 자동 토큰 갱신 후 정상 등록되는지 확인
- [ ] 비로그인 상태에서 매장 등록 시 401 반환되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 가게 생성 및 제보 기능이 로그인 필수로 변경되었습니다. 인증되지 않은 사용자는 해당 기능에 접근할 수 없으며, 로그인 후 이용 가능합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fcde-project9/GOTCHA-BE/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->