### PR TITLE
fix: S3 이미지 업로드 시 Cache-Control 헤더 추가

### DIFF
--- a/src/main/java/com/gotcha/domain/file/service/S3FileUploadService.java
+++ b/src/main/java/com/gotcha/domain/file/service/S3FileUploadService.java
@@ -79,6 +79,7 @@ public class S3FileUploadService implements FileStorageService {
                     .bucket(bucketName)
                     .key(key)
                     .contentType(file.getContentType())
+                    .cacheControl("public, max-age=31536000, immutable")
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));


### PR DESCRIPTION
## Summary
- S3 이미지 업로드 시 `Cache-Control: public, max-age=31536000, immutable` 헤더 추가
- CloudFront CDN 및 브라우저에서 이미지를 1년간 캐시하여 재방문 시 즉시 로딩
- UUID 기반 파일명이므로 immutable 캐시를 안전하게 적용 가능

## Background
앱에서 매장 리스트/상세 조회 시 이미지 로딩이 느린 문제가 보고됨.

원인 분석 결과, S3 객체에 `Cache-Control` 헤더가 없어 CloudFront와 브라우저가 이미지를 캐시하지 못하고 매번 origin에 재요청하고 있었음.

## Changes
- `S3FileUploadService.java`: `PutObjectRequest`에 `cacheControl` 설정 추가 (1줄)

## Note
- 이 PR은 **신규 업로드 이미지**에만 적용됩니다.
- 기존 S3 객체는 AWS CLI로 별도 메타데이터 업데이트 필요:

```bash
aws s3 cp s3://{bucket}/{prefix}/ s3://{bucket}/{prefix}/ \
  --recursive --metadata-directive REPLACE \
  --cache-control "public, max-age=31536000, immutable"
```

## Test plan
- [ ] `./gradlew compileJava` 빌드 성공 확인
- [ ] 이미지 업로드 후 S3 객체 메타데이터에 `Cache-Control` 헤더 포함 확인
- [ ] CloudFront 응답 헤더에 `Cache-Control` 전달 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 이미지 업로드 및 캐싱 설정이 최적화되었습니다. 업로드된 이미지가 더 효율적으로 캐시되어 반복 접근 시 빠른 로딩 속도를 제공하며, 전반적인 애플리케이션 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->