### PR TITLE
fix: DevicePlatform enum 대소문자 구분 없이 역직렬화 허용

### DIFF
--- a/src/main/java/com/gotcha/domain/push/entity/DevicePlatform.java
+++ b/src/main/java/com/gotcha/domain/push/entity/DevicePlatform.java
@@ -1,6 +1,13 @@
 package com.gotcha.domain.push.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum DevicePlatform {
     IOS,
-    ANDROID
+    ANDROID;
+
+    @JsonCreator
+    public static DevicePlatform fromString(String value) {
+        return DevicePlatform.valueOf(value.toUpperCase());
+    }
 }


### PR DESCRIPTION
## Summary
- 클라이언트에서 `"ios"` (소문자)로 platform 값을 전송 시 `DevicePlatform` enum 역직렬화 실패하는 프로덕션 에러 수정
- `@JsonCreator`를 추가하여 대소문자 구분 없이 역직렬화 허용

## Test plan
- [ ] `"ios"`, `"IOS"`, `"Ios"` 등 다양한 케이스로 디바이스 토큰 등록 API 호출 확인
- [ ] `"android"`, `"ANDROID"` 동일하게 확인
- [ ] 잘못된 값 (`"windows"` 등) 전송 시 적절한 에러 응답 확인