### PR TITLE
fix: actuator 공개 접근 제거 및 NoResourceFoundException 처리 개선

### DIFF
--- a/src/main/java/com/gotcha/_global/config/SecurityConfig.java
+++ b/src/main/java/com/gotcha/_global/config/SecurityConfig.java
@@ -103,8 +103,6 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // Actuator (management port only, not exposed externally)
-                        .requestMatchers("/actuator/**").permitAll()
                         // CORS preflight (OPTIONS) must always be allowed
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Public - 인증

--- a/src/main/java/com/gotcha/_global/exception/CommonErrorCode.java
+++ b/src/main/java/com/gotcha/_global/exception/CommonErrorCode.java
@@ -13,6 +13,9 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "VAL_002", "유효하지 않은 형식입니다"),
     INVALID_VALUE(HttpStatus.BAD_REQUEST, "VAL_003", "값이 허용 범위를 벗어났습니다"),
 
+    // 리소스 에러 (RES_XXX)
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RES_001", "요청한 리소스를 찾을 수 없습니다"),
+
     // 서버 에러 (SERVER_XXX)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "서버 내부 오류가 발생했습니다");
 

--- a/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gotcha/_global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -82,6 +83,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(FileErrorCode.FILE_TOO_LARGE.getStatus())
                 .body(ApiResponse.error(FileErrorCode.FILE_TOO_LARGE));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.warn("Resource not found: {}", e.getResourcePath());
+        return ResponseEntity
+                .status(404)
+                .body(ApiResponse.error(CommonErrorCode.RESOURCE_NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- `SecurityConfig`에서 `/actuator/**` `permitAll` 제거 — actuator는 이미 별도 management 포트에서 서빙되므로 8080에서의 공개 접근은 불필요
- `NoResourceFoundException` 전용 핸들러 추가 — 봇의 경로 스캐닝 시 ERROR → WARN 레벨로 변경하여 불필요한 Sentry 알림 방지
- `RESOURCE_NOT_FOUND` 에러 코드 추가

## Background
운영 서버에서 봇(`34.38.146.156`)이 `/actuator/sessions` 등을 스캐닝하면서 ERROR 로그 + Sentry 디스코드 알림이 발생하는 문제

## Test plan
- [ ] `./gradlew build` 성공 확인
- [ ] 배포 후 `/actuator/health` 등이 8080 포트에서 접근 불가 확인
- [ ] 존재하지 않는 경로 접근 시 WARN 레벨로 로깅되는지 확인
- [ ] Prometheus 메트릭 수집이 management 포트에서 정상 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 찾을 수 없는 리소스에 대한 오류 처리 및 응답 메시지 개선
  * 보안 설정 업데이트로 API 접근 제어 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->